### PR TITLE
feat: Google Analytics, Search Console, sitemap & robots

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Golos_Text } from "next/font/google";
 import { Providers } from "./providers";
 import { ClarityAnalytics } from "@/components/analytics/clarity";
+import { GoogleAnalytics } from "@/components/analytics/google-analytics";
+import { SITE_URL } from "@/lib/site";
 import localFont from "next/font/local";
 import "./globals.css";
 
@@ -26,6 +28,7 @@ const drukWide = localFont({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "INVITUS | Екіпірування для пауерліфтингу",
   description:
     "Український бренд екіпірування для пауерліфтингу. Атлетичні пояси, футболки, кистьові бинти та аксесуари для важкої атлетики.",
@@ -40,6 +43,11 @@ export const metadata: Metadata = {
   icons: {
     icon: "/assets/icons/favico.jpeg",
   },
+  // Google Search Console: renders <meta name="google-site-verification" ...>
+  // when GOOGLE_SITE_VERIFICATION is set (URL-prefix / HTML-tag method).
+  verification: {
+    google: process.env.GOOGLE_SITE_VERIFICATION,
+  },
 };
 
 export default function RootLayout({
@@ -52,6 +60,7 @@ export default function RootLayout({
       <body className={`${golosText.variable} ${drukWide.variable} font-sans antialiased`}>
         <Providers>{children}</Providers>
         <ClarityAnalytics />
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// Allow all crawlers — including AI/GEO bots (GPTBot, PerplexityBot, Google-Extended,
+// ClaudeBot, etc.) — so the brand can surface in AI answers. Only funnel,
+// transactional and API routes are kept out of the index.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/checkout", "/payment-result", "/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,57 @@
+import type { MetadataRoute } from "next";
+import { getAllCategorySlugs, getAllProductSlugs } from "@/lib/api";
+import { SITE_URL } from "@/lib/site";
+
+// Rebuild the sitemap at most hourly so it stays fresh without hammering the
+// KeyCRM API (60 req/min limit).
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  // Indexable static routes. Funnel/transactional pages (/checkout,
+  // /payment-result) are intentionally excluded — see robots.ts.
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/refund`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+
+  // Dynamic routes from KeyCRM — degrade gracefully: a transient outage or a
+  // missing token at build time must not break sitemap generation.
+  let categorySlugs: string[] = [];
+  let productSlugs: string[] = [];
+  try {
+    [categorySlugs, productSlugs] = await Promise.all([
+      getAllCategorySlugs(),
+      getAllProductSlugs(),
+    ]);
+  } catch {
+    // Keep just the static routes on failure.
+  }
+
+  const categoryRoutes: MetadataRoute.Sitemap = categorySlugs.map((slug) => ({
+    url: `${SITE_URL}/shop/${slug}`,
+    lastModified: now,
+    changeFrequency: "daily",
+    priority: 0.8,
+  }));
+
+  const productRoutes: MetadataRoute.Sitemap = productSlugs.map((slug) => ({
+    url: `${SITE_URL}/product/${slug}`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...categoryRoutes, ...productRoutes];
+}

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,0 +1,29 @@
+import Script from "next/script";
+
+// GA4 Measurement ID, e.g. "G-XXXXXXXXXX". Set in .env.local + Vercel envs.
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+// Loads GA4 only in production and only when an ID is configured — mirrors the
+// dev/localhost gating in ClarityAnalytics so local dev never pollutes stats.
+// SPA route changes are captured by GA4 Enhanced Measurement (on by default),
+// which tracks History API navigations that Next.js App Router uses.
+export function GoogleAnalytics() {
+  if (!GA_ID || process.env.NODE_ENV !== "production") return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the site's public origin.
+// Used by metadataBase (canonical/OG URLs), sitemap.ts and robots.ts.
+//
+// Set NEXT_PUBLIC_SITE_URL to the real production domain in .env.local AND in
+// the Vercel project env vars. The fallback is only a safety net for local dev.
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || "https://invitus.ua"
+).replace(/\/+$/, "");


### PR DESCRIPTION
## What & why

Wires up **Google Analytics 4**, **Google Search Console** verification, and a **dynamic sitemap + robots.txt** — the SEO/GEO foundation so the store gets indexed by Google and is discoverable by AI search engines.

## Analytics
- **GA4** — `components/analytics/google-analytics.tsx` loads `gtag.js` via `next/script`, mirroring the existing Clarity component: **production-only** (local dev is never tracked), reads `NEXT_PUBLIC_GA_ID`. SPA route changes are captured by GA4 Enhanced Measurement. Rendered in `app/layout.tsx` next to `<ClarityAnalytics />`.
- **Search Console** — verified through the Next Metadata API (`verification.google` ← `GOOGLE_SITE_VERIFICATION`), which renders `<meta name="google-site-verification">`.

## SEO / GEO
- **`app/sitemap.ts`** — dynamic sitemap covering the home page, `/refund`, and **all KeyCRM categories & products**. Priorities/`changeFrequency` per page type. **Resilient**: a KeyCRM outage or missing build-time token degrades to the static routes instead of failing. Revalidates hourly (`revalidate = 3600`) to respect the 60 req/min API limit. Verified locally → **49 URLs** (home, refund, 6 categories, 41 products).
- **`app/robots.ts`** — allows all crawlers **including AI/GEO bots** (GPTBot, PerplexityBot, Google-Extended, ClaudeBot) so the brand can surface in AI answers; disallows funnel/transactional routes (`/checkout`, `/payment-result`) and `/api/`; points to the sitemap.
- **`lib/site.ts`** — single `SITE_URL` source (`NEXT_PUBLIC_SITE_URL`, with a dev fallback), used by sitemap, robots and metadata.
- **`metadataBase`** in the root layout → canonical/OG URLs resolve to absolute (better Google + social/AI previews).

## Required env vars (already set in Vercel by the owner)
| Var | Purpose |
| --- | --- |
| `NEXT_PUBLIC_GA_ID` | GA4 Measurement ID (`G-XXXXXXXXXX`) |
| `GOOGLE_SITE_VERIFICATION` | GSC HTML-tag verification code |
| `NEXT_PUBLIC_SITE_URL` | Production origin used by sitemap/robots/canonicals |

> Note: `.env.example` is git-ignored in this repo, so the vars are documented here rather than in that file.

## Verification
- `tsc --noEmit`: 0 errors. `eslint`: clean on changed files.
- Dev server: `/robots.txt` and `/sitemap.xml` render valid output (sitemap pulls live KeyCRM data).

## Follow-ups (not in this PR)
- After deploy: submit `https://<domain>/sitemap.xml` in Search Console.
- Recommended next: **JSON-LD structured data** (`Product` / `Organization` / `BreadcrumbList`) for rich results and stronger AI/GEO parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
