### PR TITLE
Uniform 4-column catalog grid

### DIFF
--- a/components/sections/catalog-grid.tsx
+++ b/components/sections/catalog-grid.tsx
@@ -35,39 +35,19 @@ export function CatalogGrid({ products }: CatalogGridProps) {
     );
   }
 
-  // Create grid items with size information
-  // Pattern: 2 large, 4 small, 4 small, 2 large (repeating)
-  // Large cards span 2 columns, small cards span 1 column
-  const getItemSize = (index: number): "large" | "small" => {
-    const patternPosition = index % 12;
-    // Positions 0,1 and 10,11 are large (2 at start, 2 at end of 12-item cycle)
-    if (patternPosition < 2 || patternPosition >= 10) {
-      return "large";
-    }
-    return "small";
-  };
-
   return (
     <section className="bg-black">
       <div className="container-main">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-4 lg:gap-x-4 lg:gap-y-6">
-          {products.map((product, index) => {
-            const isLarge = getItemSize(index) === "large";
-            return (
-              <FadeUp
-                key={product.id}
-                duration={0.5}
-                delay={(index % 4) * 0.1}
-                className={isLarge ? "lg:col-span-2" : "lg:col-span-1"}
-              >
-                <ProductCard
-                  product={product}
-                  index={index}
-                  listName={LIST_NAME}
-                />
-              </FadeUp>
-            );
-          })}
+          {products.map((product, index) => (
+            <FadeUp key={product.id} duration={0.5} delay={(index % 4) * 0.1}>
+              <ProductCard
+                product={product}
+                index={index}
+                listName={LIST_NAME}
+              />
+            </FadeUp>
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What & why

`/shop/[category]` catalog grid used a repeating "2 large, 4 small, 4 small, 2 large" pattern (large cards spanning 2 columns via `lg:col-span-2`, cycling every 12 items). Replaced with a plain uniform grid — every card is the same size, 4 per row on desktop.

## Change
- `components/sections/catalog-grid.tsx`: removed `getItemSize`/`col-span` logic entirely; grid stays `grid-cols-1 lg:grid-cols-4` with all cards equal width.

## Verification
- `tsc --noEmit`: 0 errors. `eslint`: clean.
- Verified visually on `/shop/belts` at desktop width — uniform 4-per-row grid, no oversized cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
