### PR TITLE
feat: Strapi heroImage override for main product photo

### DIFF
--- a/content/product-extras.ts
+++ b/content/product-extras.ts
@@ -12,6 +12,12 @@ import type { ProductImage } from "@/types";
 export interface ProductExtras {
   /** Path to a .glb under public/models/ (or a full URL). */
   model3dUrl?: string;
+  /**
+   * Main product photo — overrides the KeyCRM thumbnail when present.
+   * Use it when KeyCRM's photo has a baked-in background and Strapi holds a
+   * cleaner (e.g. transparent) shot for the hero slot.
+   */
+  heroImage?: ProductImage;
   /** Hero background image for the product page (falls back to product_bg.png). */
   bgImage?: ProductImage;
   /** Gallery rendered below the product; overrides KeyCRM attachments when present. */

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -83,10 +83,6 @@ function toProduct(
   const category =
     p.category_id != null ? categoryById.get(p.category_id) : undefined;
 
-  const mainImage = p.thumbnail_url
-    ? { url: p.thumbnail_url, alt: p.name }
-    : undefined;
-
   const galleryImages = (p.attachments_data ?? [])
     .filter((url) => url !== p.thumbnail_url)
     .map((url) => ({ url, alt: p.name }));
@@ -116,6 +112,12 @@ function toProduct(
 
   const slug = slugify(p.name);
   const extras = resolveExtras(extrasIndex, p.id, slug);
+
+  // Strapi's heroImage wins when set (e.g. a transparent shot), otherwise the
+  // KeyCRM thumbnail. Products without a Strapi override keep KeyCRM's photo.
+  const mainImage =
+    extras?.heroImage ??
+    (p.thumbnail_url ? { url: p.thumbnail_url, alt: p.name } : undefined);
 
   return {
     id: p.id.toString(),

--- a/lib/product-extras.ts
+++ b/lib/product-extras.ts
@@ -8,8 +8,13 @@
 // ("Poseidon Lifting Belt" in Strapi and KeyCRM), while Strapi's own slug
 // field uses a different convention ("belt-poseidon") and cannot be used.
 //
-// Resilient by design: single attempt, 4s timeout, 60s back-off after a
+// Resilient by design: single attempt, 10s timeout, 60s back-off after a
 // failure — a down Strapi degrades the site to fallbacks, never blocks it.
+// The timeout is generous on purpose: Strapi Cloud's free tier sleeps when
+// idle and cold-starts in ~6-7s, so a tighter budget would drop presentation
+// content (hero/bg images) for the first visitor after every quiet spell.
+// Once warm it answers in ~0.15s, and revalidate:300 means only one request
+// per 5 min ever pays the cold-start cost.
 
 import { getStrapiURL, getStrapiMedia } from "./strapi";
 import { slugify } from "./slugify";
@@ -30,16 +35,29 @@ const EMPTY: ExtrasIndex = { byKeycrmId: new Map(), bySlug: new Map() };
 // doesn't add latency to every page render.
 let skipUntil = 0;
 
-export async function getStrapiExtras(): Promise<ExtrasIndex> {
-  if (Date.now() < skipUntil) return EMPTY;
+// Single-flight guard: while one fetch is in progress, concurrent callers
+// share its promise instead of each opening their own request. Without this,
+// a burst of page renders on a cold (sleeping) Strapi each waited the full
+// timeout in parallel, stacking into tens of seconds of dev render time.
+let inFlight: Promise<ExtrasIndex> | null = null;
 
+export function getStrapiExtras(): Promise<ExtrasIndex> {
+  if (Date.now() < skipUntil) return Promise.resolve(EMPTY);
+  if (inFlight) return inFlight;
+  inFlight = fetchStrapiExtras().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function fetchStrapiExtras(): Promise<ExtrasIndex> {
   try {
     const response = await fetch(
       getStrapiURL(
-        "/api/products?populate[model3d]=true&populate[backgroundImage]=true&populate[galleryImages][populate]=image&pagination[limit]=100"
+        "/api/products?populate[model3d]=true&populate[heroImage]=true&populate[backgroundImage]=true&populate[galleryImages][populate]=image&pagination[limit]=100"
       ),
       {
-        signal: AbortSignal.timeout(4000),
+        signal: AbortSignal.timeout(10000),
         next: { revalidate: 300, tags: ["strapi-extras"] },
       }
     );
@@ -60,6 +78,12 @@ export async function getStrapiExtras(): Promise<ExtrasIndex> {
 
       const extras: ProductExtras = {
         model3dUrl: p.model3d ? getStrapiMedia(p.model3d.url) : undefined,
+        heroImage: p.heroImage
+          ? {
+              url: getStrapiMedia(p.heroImage.url),
+              alt: p.heroImage.alternativeText || p.name,
+            }
+          : undefined,
         bgImage: p.backgroundImage
           ? {
               url: getStrapiMedia(p.backgroundImage.url),


### PR DESCRIPTION
## Що
Дозволяє Strapi-полю `heroImage` перекривати KeyCRM-thumbnail для головного фото товару.

Категорії, зведені цієї ітерації з прозорими PNG (кистьові бинти, лямки-вісімки, наколінники), тепер показують чисте фото на фоні-сцені замість KeyCRM-thumbnail із запеченим білим фоном. Товари **без** Strapi-перекриття (пояси тощо) лишаються на фото з KeyCRM — нічого не зачеплено.

## Зміни
- **`lib/api.ts`** — `mainImage` віддає перевагу `extras.heroImage`, інакше KeyCRM-thumbnail.
- **`content/product-extras.ts`** — нове поле `ProductExtras.heroImage`.
- **`lib/product-extras.ts`**:
  - `populate[heroImage]` + мапінг зі Strapi;
  - **single-flight** — одночасні рендери ділять один запит до Strapi замість того, щоб кожен чекав свій таймаут на холодному (сплячому) Strapi;
  - таймаут **4с → 10с** — щоб переживати холодний старт безкоштовного тарифу Strapi Cloud (~6-7с); завдяки `revalidate:300` холодна ціна платиться раз на 5 хв.

## Перевірено
- Головне фото на сторінці товару = прозорий PNG зі Strapi (перевірено на бинтах Akatsuki/Poseidon у браузері).
- Дані всіх 17 нових товарів (10 бинтів + 4 лямки + 3 наколінники): `hero=.png`, `bg=.jpg`.
- `tsc --noEmit` — чисто.
- Пояси не зачеплені (у них Strapi `heroImage` порожній).

## Прод
Не впливає на швидкість прода: `next build`/`start` нічого не вотчать. Таймаут-фікс стосується лише холодного старту Strapi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)