### PR TITLE
feat: KeyCRM thumbnail in lists, Strapi hero on product page

### DIFF
--- a/components/product/product-page-content.tsx
+++ b/components/product/product-page-content.tsx
@@ -73,7 +73,7 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
                 />
               ) : (
                 <ProductMedia
-                  image={product.mainImage}
+                  image={product.heroImage}
                   alt={product.name}
                   fill
                   className="object-contain"
@@ -150,7 +150,7 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
           <div className="absolute inset-0 z-10 flex items-center justify-center pb-40">
             <div className="relative w-full max-w-[520px] aspect-square">
               <ProductMedia
-                image={product.mainImage}
+                image={product.heroImage}
                 alt={product.name}
                 fill
                 className="object-contain"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -113,11 +113,16 @@ function toProduct(
   const slug = slugify(p.name);
   const extras = resolveExtras(extrasIndex, p.id, slug);
 
-  // Strapi's heroImage wins when set (e.g. a transparent shot), otherwise the
-  // KeyCRM thumbnail. Products without a Strapi override keep KeyCRM's photo.
-  const mainImage =
-    extras?.heroImage ??
-    (p.thumbnail_url ? { url: p.thumbnail_url, alt: p.name } : undefined);
+  // Two distinct photo slots:
+  //   mainImage — the KeyCRM thumbnail (clean white-bg studio shot). Used in
+  //     list contexts: catalog cards, cart drawer, checkout summary.
+  //   heroImage — the big product-page hero. Prefers Strapi's heroImage (e.g. a
+  //     transparent shot that sits on the scene background), else the thumbnail.
+  const keycrmThumb = p.thumbnail_url
+    ? { url: p.thumbnail_url, alt: p.name }
+    : undefined;
+  const mainImage = keycrmThumb;
+  const heroImage = extras?.heroImage ?? keycrmThumb;
 
   return {
     id: p.id.toString(),
@@ -132,7 +137,7 @@ function toProduct(
     careInstructions: extras?.careInstructions,
 
     mainImage,
-    heroImage: mainImage,
+    heroImage,
     bgImage: extras?.bgImage,
     galleryImages: extras?.galleryImages ?? galleryImages,
 


### PR DESCRIPTION
## Що
Розводить два фото-слоти, щоб кожен контекст показував свій кадр:

- **Каталог / кошик / чекаут / картки схожих товарів** → `mainImage` = **KeyCRM-thumbnail** (чисте студійне фото на білому).
- **Герой на сторінці товару** → `heroImage` = **Strapi PNG** (прозорий, лягає на фон-сцену), або KeyCRM-thumbnail, якщо перекриття немає.

## Навіщо
До цього Strapi-перекриття йшло в `mainImage`, і прозорий кадр протікав також у картки каталогу/кошика. Тепер сторінка товару читає `product.heroImage`, а списки лишаються на `product.mainImage`.

## Зміни
- `lib/api.ts` — `mainImage = keycrmThumb`; `heroImage = extras?.heroImage ?? keycrmThumb`.
- `components/product/product-page-content.tsx` — герой (мобілка + десктоп) читає `product.heroImage`.

## Перевірено (dev, curl рендерених `<img>`)
- `/shop/straps` — усі картки = KeyCRM-thumbnail ✅
- `/product/red-8-strap` — герой = Strapi Red PNG + фон-сцена; картки схожих = KeyCRM ✅
- Усі герой-PNG (бинти/лямки/наколінники) прозорі — білих квадратів на сцені не буде.
- `tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)