### PR TITLE
feat: прихована сторінка на 0,50 ₴ для перевірки бойового еквайрингу

### DIFF
--- a/app/test-290732443/page.tsx
+++ b/app/test-290732443/page.tsx
@@ -1,0 +1,44 @@
+// Hidden smoke-test page for live acquiring.
+//
+// Not linked from anywhere, not in the sitemap, noindex. It drops the 0.50 UAH
+// test product (KeyCRM id 44, in the hidden "Службове (тест)" category) into the
+// cart and hands over to the normal checkout — so a real-card test runs through
+// exactly the same pricing, order and payment code as a customer would, for 50
+// copecks instead of 120.50 (orders containing only this product ship free).
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { fetchKeyCrm } from "@/lib/keycrm";
+import { TEST_PRODUCT_ID } from "@/lib/orders";
+import type { KeyCrmProduct } from "@/lib/keycrm-schema";
+import type { Product } from "@/types";
+import { TestCheckoutStarter } from "./test-checkout-starter";
+
+export const metadata: Metadata = {
+  title: "Перевірка оплати | INVITUS",
+  robots: { index: false, follow: false },
+};
+
+// Always read the live price — this page exists to prove what really happens.
+export const dynamic = "force-dynamic";
+
+export default async function TestPaymentPage() {
+  let raw: KeyCrmProduct;
+  try {
+    raw = await fetchKeyCrm<KeyCrmProduct>(`/products/${TEST_PRODUCT_ID}`, {
+      revalidate: 0,
+    });
+  } catch {
+    notFound();
+  }
+
+  const product: Product = {
+    id: String(raw.id),
+    documentId: String(raw.id),
+    name: raw.name,
+    slug: `test-${raw.id}`,
+    price: raw.min_price,
+  };
+
+  return <TestCheckoutStarter product={product} />;
+}

--- a/app/test-290732443/test-checkout-starter.tsx
+++ b/app/test-290732443/test-checkout-starter.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCartStore } from "@/stores/cart";
+import { formatPriceWithCurrency } from "@/lib/format";
+import { CTAButton } from "@/components/ui/cta-button";
+import type { Product } from "@/types";
+
+export function TestCheckoutStarter({ product }: { product: Product }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const start = () => {
+    setBusy(true);
+    // Replace the cart rather than add to it: a leftover belt would turn a
+    // 50-copeck test into a real-money one, and would put shipping back.
+    useCartStore.setState({
+      items: [{ product, quantity: 1 }],
+      isOpen: false,
+    });
+    router.push("/checkout");
+  };
+
+  return (
+    <main className="bg-black min-h-screen flex items-center justify-center px-6">
+      <div className="w-full max-w-lg bg-surface rounded-4xl p-8 lg:p-12">
+        <p className="text-xs font-bold uppercase tracking-wider text-coral mb-3">
+          Службова сторінка
+        </p>
+        <h1 className="font-heading text-2xl lg:text-3xl font-bold text-white mb-4">
+          Перевірка бойового еквайрингу
+        </h1>
+
+        <p className="text-body-2 text-white/70 mb-8">
+          Кладе в кошик тестовий товар і відкриває звичайний чекаут. Замовлення
+          пройде тим самим кодом, що й справжнє: ціна з KeyCRM, замовлення в
+          CRM, інвойс Monobank, підтвердження вебхуком.
+        </p>
+
+        <dl className="text-sm border-t border-white/10 divide-y divide-white/10 mb-8">
+          <div className="flex justify-between py-3">
+            <dt className="text-white/60">Товар</dt>
+            <dd className="text-white text-right">{product.name}</dd>
+          </div>
+          <div className="flex justify-between py-3">
+            <dt className="text-white/60">Ціна</dt>
+            <dd className="text-white">{formatPriceWithCurrency(product.price)}</dd>
+          </div>
+          <div className="flex justify-between py-3">
+            <dt className="text-white/60">Доставка</dt>
+            <dd className="text-white">0 ₴ — для цього товару не нараховується</dd>
+          </div>
+        </dl>
+
+        <CTAButton width="fill" onClick={start} disabled={busy}>
+          {busy ? "Відкриваю чекаут…" : "Почати перевірку"}
+        </CTAButton>
+
+        <p className="text-xs text-white/40 mt-6">
+          Оплата справжня. Після перевірки поверни кошти в кабінеті Monobank і
+          познач замовлення в KeyCRM як тестове.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -42,6 +42,7 @@ const CATEGORY_SLUG_BY_ID: Record<number, string> = {
 // every consumer is covered. To bring a category back, just remove its id.
 const HIDDEN_CATEGORY_IDS = new Set<number>([
   6, // Футболки — поки немає в продажу
+  7, // Службове (тест) — 0.50 ₴ товар для перевірки бойового еквайрингу
 ]);
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -17,6 +17,17 @@ import { SHIPPING_COST } from "./shipping";
 const SIZE_PROPERTY = "Розмір";
 const NOVA_POSHTA_DELIVERY_SERVICE_ID = 2;
 
+/**
+ * KeyCRM id of the hidden 0.50 UAH product used to smoke-test live acquiring
+ * (category 7 "Службове (тест)", filtered out of the catalog in lib/api.ts).
+ *
+ * An order containing only this product ships free, so a real-card test costs
+ * 50 copecks rather than 120.50 UAH. It stays a normal product otherwise —
+ * priced, recorded and paid through exactly the same code as everything else,
+ * which is the entire point of testing with it.
+ */
+export const TEST_PRODUCT_ID = 44;
+
 export interface OrderDraftItem {
   /** KeyCRM product id. */
   productId: number;
@@ -85,12 +96,14 @@ export async function priceOrder(draft: OrderDraft): Promise<PricedOrder> {
   );
 
   const subtotal = lines.reduce((sum, l) => sum + l.lineTotal, 0);
-  const total = subtotal + SHIPPING_COST;
+  const isTestOnly = lines.every((l) => l.productId === TEST_PRODUCT_ID);
+  const shipping = isTestOnly ? 0 : SHIPPING_COST;
+  const total = subtotal + shipping;
 
   return {
     lines,
     subtotal,
-    shipping: SHIPPING_COST,
+    shipping,
     total,
     // Round once, at the end, on the final UAH figure — rounding per line and
     // summing copecks can drift from what the customer saw.


### PR DESCRIPTION
Пісочниця ніколи не перевіряє те, що справді має значення: 3-D Secure, банк-емітент і **справжній підпис Monobank** на вебхуку бувають лише з бойовими ключами та реальною карткою. Але така перевірка не має коштувати 120,50 ₴.

## Що додано

`/test-290732443` — нікуди не злінкована, відсутня в sitemap, `noindex, nofollow`.

Кладе в кошик товар за **0,50 ₴** (KeyCRM id 44, нова категорія «Службове (тест)», яку `lib/api.ts` відфільтровує з каталогу) і відкриває **звичайний чекаут**. Тобто перевірка проходить тим самим кодом, що й справжнє замовлення: ціна з KeyCRM, замовлення в CRM, інвойс Monobank, підтвердження вебхуком.

У платіжному шляху лише одна тестова гілка: замовлення, яке містить **тільки** цей товар, не тарифікує доставку — саме це дає 50 копійок замість 120,50.

Сторінка **замінює** кошик, а не додає до нього: забутий після перегляду пояс тихо перетворив би 50-копійчану перевірку на реальні гроші й повернув би доставку.

## Перевірено

- Сторінка віддає `noindex, nofollow` і живу ціну `0,5 ₴`
- Тестовий товар не з'являється ні на головній, ні в каталозі поясів, ні в наколінниках, ні в sitemap
- Замовлення лише з ним: `total: 0.5`, інвойс Monobank рівно на **50 копійок**
- Звичайний пояс і далі рахується як `4220` — доставка на місці

## Як користуватись

1. Відкрити `/test-290732443` на проді з бойовим токеном
2. Пройти чекаут і оплатити справжньою карткою
3. У логах Vercel має бути `[Monobank webhook] order NNNN marked paid` — це і є доказ, що справжній підпис проходить перевірку
4. Повернути 50 копійок у кабінеті Monobank і прибрати замовлення з KeyCRM