### PR TITLE
fix: clear the four react-hooks lint errors without muting the rule

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
 import { useCartCount, useOpenCart } from "@/hooks/use-cart";
+import { useIsHydrated } from "@/hooks/use-is-hydrated";
 import { useMenuStore } from "@/stores/menu";
 import { cn } from "@/lib/utils";
 import { navLinks } from "@/content/navigation";
@@ -11,15 +12,13 @@ import MenuIcon from "@/public/assets/icons/menu-icon.svg";
 
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+  // The cart lives in localStorage, so its count only exists on the client —
+  // rendering it during hydration would not match the server's markup.
+  const isHydrated = useIsHydrated();
   const pathname = usePathname();
   const itemCount = useCartCount();
   const openCart = useOpenCart();
   const openMenu = useMenuStore((state) => state.openMenu);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -77,7 +76,7 @@ export function Header() {
               onClick={openCart}
               className="p-2 text-white text-base leading-6 font-medium cursor-pointer"
             >
-              Кошик ({isMounted ? itemCount : 0})
+              Кошик ({isHydrated ? itemCount : 0})
             </button>
 
             <button

--- a/components/models/model-loader.tsx
+++ b/components/models/model-loader.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ArnoldLoader } from "@/components/ui/arnold-loader";
+import { useIsHydrated } from "@/hooks/use-is-hydrated";
 import { Canvas, useThree } from "@react-three/fiber";
 import {
   OrbitControls,
@@ -13,19 +14,25 @@ import * as THREE from "three";
 import { DynamicModel, FallbackModel } from "./dynamic-model";
 
 function CameraController() {
-  const { camera, size } = useThree();
+  // Read through r3f's store getter rather than destructuring the camera out of
+  // useThree(). Mutating a three.js object is the whole r3f model, but a value
+  // handed straight back from a hook is not ours to mutate — and calling get()
+  // inside the effect also guarantees the camera that is current when the
+  // effect runs, not the one captured at render time.
+  const get = useThree((state) => state.get);
+  const width = useThree((state) => state.size.width);
 
   useEffect(() => {
-    const cam = camera as THREE.PerspectiveCamera;
-    if (size.width >= 1024) {
-      cam.fov = 38; // desktop — slightly zoomed out
-    } else if (size.width >= 768) {
-      cam.fov = 22; // tablet — zoomed in
+    const camera = get().camera as THREE.PerspectiveCamera;
+    if (width >= 1024) {
+      camera.fov = 38; // desktop — slightly zoomed out
+    } else if (width >= 768) {
+      camera.fov = 22; // tablet — zoomed in
     } else {
-      cam.fov = 26; // mobile — zoomed in
+      camera.fov = 26; // mobile — zoomed in
     }
-    cam.updateProjectionMatrix();
-  }, [camera, size.width]);
+    camera.updateProjectionMatrix();
+  }, [get, width]);
 
   return null;
 }
@@ -83,11 +90,9 @@ function LoadingOverlay() {
 
 // Main component with Canvas and loading
 export function ModelLoader({ modelUrl, fallbackModelUrl }: ModelLoaderProps) {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+  // WebGL has no server-side equivalent, so the canvas cannot be part of the
+  // server render — show the loader until hydration has happened.
+  const isClient = useIsHydrated();
 
   if (!isClient) {
     return (

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import { motion } from "framer-motion";
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
@@ -19,7 +25,6 @@ export function TestimonialsSection() {
     startIndex: START_INDEX,
   });
 
-  const [selectedIndex, setSelectedIndex] = useState(START_INDEX);
   const [isMuted, setIsMuted] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
@@ -46,19 +51,26 @@ export function TestimonialsSection() {
     [emblaApi]
   );
 
-  const onSelect = useCallback(() => {
-    if (!emblaApi) return;
-    setSelectedIndex(emblaApi.selectedScrollSnap());
-  }, [emblaApi]);
+  // Embla already owns the current slide, so mirroring it into React state only
+  // creates a second copy to keep in sync — and the sync had to happen inside an
+  // effect, which is what made it a cascading render. Subscribing to the
+  // carousel as an external store reads the value straight from the source.
+  const subscribeToEmbla = useCallback(
+    (onChange: () => void) => {
+      if (!emblaApi) return () => {};
+      emblaApi.on("select", onChange).on("reInit", onChange);
+      return () => {
+        emblaApi.off("select", onChange).off("reInit", onChange);
+      };
+    },
+    [emblaApi]
+  );
 
-  useEffect(() => {
-    if (!emblaApi) return;
-    onSelect();
-    emblaApi.on("select", onSelect);
-    return () => {
-      emblaApi.off("select", onSelect);
-    };
-  }, [emblaApi, onSelect]);
+  const selectedIndex = useSyncExternalStore(
+    subscribeToEmbla,
+    () => emblaApi?.selectedScrollSnap() ?? START_INDEX,
+    () => START_INDEX
+  );
 
   // Manage video playback - only play the selected video
   useEffect(() => {

--- a/hooks/use-is-hydrated.ts
+++ b/hooks/use-is-hydrated.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+// Hydration is not "external state that changes", so there is nothing to
+// subscribe to — the snapshot pair alone carries the whole meaning.
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * `false` while rendering on the server and through hydration, `true` after.
+ *
+ * Use it to gate markup that cannot match between server and client — a cart
+ * count read from localStorage, a WebGL canvas — where rendering the real value
+ * straight away would be a hydration mismatch.
+ *
+ * This replaces the usual `useState(false)` + `useEffect(() => setMounted(true))`
+ * pair. Same behaviour, minus a second render pass, and without a setState in an
+ * effect body for the linter to object to.
+ */
+export function useIsHydrated(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
`pnpm lint` has been failing on four errors that predate any recent work. All
four are real patterns the React 19 rules object to, so each is rewritten rather
than suppressed — no `eslint-disable` added.

## setState inside an effect (three of them)

Two are the "am I on the client yet" dance: the header hides a localStorage cart
count through hydration, and the WebGL canvas cannot exist server-side at all.
New `useIsHydrated()` says the same thing with `useSyncExternalStore`, whose
server snapshot *is* the "not yet" answer — same behaviour, one render pass
fewer, nothing for the rule to flag.

The third was the testimonials carousel mirroring embla's current slide into
React state and re-syncing it from an effect. Embla already owns that value, so
subscribing to its `select`/`reInit` events as an external store reads it from
the source and both the copy and the effect disappear.

## Mutating a hook's return value (one)

`CameraController` destructured `camera` out of `useThree()` and set `fov` on it.
Mutating three.js objects is the entire r3f model, but a value handed straight
back from a hook is not ours to mutate. Reading it through the store's own
`get()` inside the effect is also just better: it yields the camera current when
the effect runs rather than one captured at render time.

## Verified in a real browser

- Carousel: next/prev still move the highlighted card (1 → 2 → 1).
- Product page: the WebGL canvas mounts at 1408×868 with a live context and the
  belt renders at the same framing as before.
- Header: cart count still appears after hydration.

`pnpm lint` and `tsc` both exit 0.

## Unrelated bug found while verifying — not fixed here

Every page showing a price throws a hydration mismatch, on `main` today. Node
and the browser disagree about `Intl.NumberFormat("uk-UA", {currency: "UAH"})`:

```
node    → "4 100 ₴"    (U+20B4)
browser → "4 100 грн"
```

`formatPriceWithCurrency` in `lib/format.ts` therefore renders different text on
each side and React throws the tree away and re-renders it. Worth its own PR —
formatting the number and appending `₴` in JSX, the way `formatPrice` is already
used elsewhere, would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)