### PR TITLE
fix: price text differed between server and client, failing hydration

### DIFF
--- a/lib/format.ts
+++ b/lib/format.ts
@@ -8,18 +8,27 @@ const UAH_FORMATTER = new Intl.NumberFormat("uk-UA", {
   minimumFractionDigits: 0,
 });
 
-const UAH_CURRENCY_FORMATTER = new Intl.NumberFormat("uk-UA", {
-  style: "currency",
-  currency: "UAH",
-  minimumFractionDigits: 0,
-});
+// Non-breaking, so the symbol can never be left stranded on its own line.
+const CURRENCY_SYMBOL = " ₴";
 
 // Plain number, e.g. "1 999". Use when the ₴ symbol is rendered separately.
 export function formatPrice(amount: number): string {
   return UAH_FORMATTER.format(amount);
 }
 
-// Includes the currency symbol (₴) per Ukrainian locale conventions.
+/**
+ * Price with the ₴ symbol, e.g. "1 999 ₴".
+ *
+ * The symbol is appended rather than left to `style: "currency"`, because that
+ * is not deterministic across runtimes: Node's ICU renders UAH as "4 100 ₴"
+ * while browsers render "4 100 грн". Every page showing a price was therefore
+ * failing hydration on the text alone, and React was throwing the tree away and
+ * re-rendering it client-side.
+ *
+ * Only the digits come from Intl now, and those already agree on both sides
+ * (same U+00A0 group separator), so the output is identical everywhere — and it
+ * matches how the rest of the UI writes prices, as `{formatPrice(x)} ₴`.
+ */
 export function formatPriceWithCurrency(amount: number): string {
-  return UAH_CURRENCY_FORMATTER.format(amount);
+  return `${formatPrice(amount)}${CURRENCY_SYMBOL}`;
 }


### PR DESCRIPTION
Found while verifying #19. Every page that renders a price has been failing
hydration on `main`.

Node's ICU and the browser's disagree about the same format call:

```js
new Intl.NumberFormat("uk-UA", { style: "currency", currency: "UAH" }).format(4100)

node    → "4 100 ₴"    (U+20B4)
browser → "4 100 грн"
```

`formatPriceWithCurrency` therefore put one string in the HTML and produced a
different one on hydration. React cannot patch a text mismatch — it throws the
subtree away and re-renders it client-side, which on the product page is the
entire hero, and it logged an error on every load.

## The fix

Take only the digits from `Intl` and append the symbol. The number part already
agreed across runtimes (same U+00A0 group separator), so the result is now
identical on both sides. It also matches how every other surface writes a price
— `{formatPrice(x)} ₴` in the catalog, cart drawer and checkout — and the
convention recorded in CLAUDE.md.

## One visible change

The product page now reads **"4 100 ₴"** where the browser used to render
"4 100 грн". The server was already sending ₴, and the rest of the site has
always shown ₴, so this is the site agreeing with itself rather than a new
decision. Say the word if "грн" was the intent and it should go the other way.

## Verified

Playwright, product page: **zero console errors**, down from the hydration
failure present on `main`. Screenshot shows the hero rendering with "4 100 ₴".

🤖 Generated with [Claude Code](https://claude.com/claude-code)