### PR TITLE
feat: canonical URLs and Product/Organization/Breadcrumb JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,9 @@ import { Golos_Text } from "next/font/google";
 import { Providers } from "./providers";
 import { ClarityAnalytics } from "@/components/analytics/clarity";
 import { GoogleAnalytics } from "@/components/analytics/google-analytics";
+import { JsonLd } from "@/components/seo/json-ld";
 import { SITE_URL } from "@/lib/site";
+import { organizationSchema } from "@/lib/structured-data";
 import localFont from "next/font/local";
 import "./globals.css";
 
@@ -48,6 +50,10 @@ export const metadata: Metadata = {
   verification: {
     google: process.env.GOOGLE_SITE_VERIFICATION,
   },
+  // No `alternates.canonical` here on purpose: metadata is inherited by every
+  // segment that does not override it, so a canonical set at the root would
+  // declare the homepage as the canonical of the entire site. Each page
+  // declares its own.
 };
 
 export default function RootLayout({
@@ -59,6 +65,7 @@ export default function RootLayout({
     <html lang="uk" className="dark">
       <body className={`${golosText.variable} ${drukWide.variable} font-sans antialiased`}>
         <Providers>{children}</Providers>
+        <JsonLd data={organizationSchema()} />
         <ClarityAnalytics />
         <GoogleAnalytics />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,14 @@ import { FAQSection } from "@/components/sections/faq-section";
 import { BenefitsGrid } from "@/components/sections/benefits-grid";
 import { MotivationSection } from "@/components/sections/motivation-section";
 import { getFeaturedProducts } from "@/lib/api";
+import type { Metadata } from "next";
+
+// Title and description are inherited from the root layout; this only pins the
+// canonical, so the homepage served from a preview deploy or any other host
+// still points the index at the real domain.
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 export default async function Home() {
   const featuredProducts = await getFeaturedProducts(4);

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -7,7 +7,14 @@ import { ProductImagesSection } from "@/components/product/product-images-sectio
 import { RelatedProducts } from "@/components/product/related-products";
 import { FAQSection } from "@/components/sections/faq-section";
 import { BenefitsGrid } from "@/components/sections/benefits-grid";
-import { getProductBySlug, getAllProductSlugs, getProducts } from "@/lib/api";
+import { JsonLd } from "@/components/seo/json-ld";
+import {
+  getProductBySlug,
+  getAllProductSlugs,
+  getProducts,
+  getCategoryBySlug,
+} from "@/lib/api";
+import { breadcrumbSchema, productSchema } from "@/lib/structured-data";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -26,6 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {
       title: `${product.name} | INVITUS`,
       description: product.description,
+      alternates: { canonical: `/product/${slug}` },
     };
   } catch {
     return { title: "Товар | INVITUS" };
@@ -50,15 +58,32 @@ export default async function ProductPage({ params }: Props) {
     notFound();
   }
 
-  const relatedProducts = await getProducts({
-    category: product.category,
-    limit: 4,
-  }).then((products) =>
-    products.filter((p) => p.slug !== slug).slice(0, 4)
-  );
+  const [relatedProducts, category] = await Promise.all([
+    getProducts({ category: product.category, limit: 4 }).then((products) =>
+      products.filter((p) => p.slug !== slug).slice(0, 4)
+    ),
+    // Only needed for the breadcrumb trail and the Product `category` field;
+    // the categories listing is already cached, so this is not an extra
+    // round-trip to KeyCRM in practice.
+    product.category ? getCategoryBySlug(product.category) : null,
+  ]);
+
+  const breadcrumbs = [
+    { name: "Головна", path: "/" },
+    ...(category
+      ? [{ name: category.name, path: `/shop/${category.slug}` }]
+      : []),
+    { name: product.name, path: `/product/${product.slug}` },
+  ];
 
   return (
     <>
+      <JsonLd
+        data={[
+          productSchema(product, category?.name),
+          breadcrumbSchema(breadcrumbs),
+        ]}
+      />
       <Header />
       <ProductPageContent product={product} />
       <ProductImagesSection images={product.galleryImages || []} />

--- a/app/refund/page.tsx
+++ b/app/refund/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = {
   title: "Повернення без питань | INVITUS",
   description:
     "Повертай екіп INVITUS протягом 14 днів. Зворотну доставку оплачуємо ми, а гроші повертаємо на картку за 1-3 робочі дні.",
+  alternates: { canonical: "/refund" },
 };
 
 export default function RefundRoute() {

--- a/app/shop/[category]/page.tsx
+++ b/app/shop/[category]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/api";
 import { ALL_FILTER_SLUG } from "@/lib/filter";
 import { breadcrumbSchema } from "@/lib/structured-data";
+import type { Category } from "@/types";
 
 interface PageProps {
   params: Promise<{ category: string }>;
@@ -70,32 +71,16 @@ export async function generateMetadata({
 }
 
 async function CatalogContent({
-  categorySlug,
+  category,
   filter,
 }: {
-  categorySlug: string;
+  category: Category;
   filter: string;
 }) {
-  const [category, products] = await Promise.all([
-    getCategoryBySlug(categorySlug),
-    getProducts({ category: categorySlug, filter }),
-  ]);
-
-  if (!category) {
-    notFound();
-  }
+  const products = await getProducts({ category: category.slug, filter });
 
   return (
     <>
-      {/* Inside Suspense because the category name only exists once this
-          resolves. It still lands in the streamed HTML response, so crawlers
-          see it without running any JS. */}
-      <JsonLd
-        data={breadcrumbSchema([
-          { name: "Головна", path: "/" },
-          { name: category.name, path: `/shop/${category.slug}` },
-        ])}
-      />
       <PageHero title={`${category.name} (${products.length})`} />
       <CatalogGrid products={products} />
     </>
@@ -110,12 +95,28 @@ export default async function ShopCategoryPage({
   const { filter } = await searchParams;
   const activeFilter = filter || ALL_FILTER_SLUG;
 
+  // Resolved here rather than inside <Suspense>. Once the shell has streamed,
+  // the 200 is already on the wire, so a notFound() deeper in the tree renders
+  // the not-found screen under a 200 — a soft 404 that Google happily keeps in
+  // the index. Only the category list is awaited (small and cached); the slow
+  // products fetch stays behind the skeleton.
+  const category = await getCategoryBySlug(categorySlug);
+  if (!category) {
+    notFound();
+  }
+
   return (
     <>
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Головна", path: "/" },
+          { name: category.name, path: `/shop/${category.slug}` },
+        ])}
+      />
       <Header />
       <main>
         <Suspense fallback={<CatalogSkeleton />}>
-          <CatalogContent categorySlug={categorySlug} filter={activeFilter} />
+          <CatalogContent category={category} filter={activeFilter} />
         </Suspense>
         <FAQSection />
         <BenefitsGrid />

--- a/app/shop/[category]/page.tsx
+++ b/app/shop/[category]/page.tsx
@@ -10,6 +10,7 @@ import { FAQSection } from "@/components/sections/faq-section";
 import { BenefitsGrid } from "@/components/sections/benefits-grid";
 import { CartDrawer } from "@/components/layout/cart-drawer";
 import { CatalogSkeleton } from "@/components/sections/catalog-skeleton";
+import { JsonLd } from "@/components/seo/json-ld";
 
 import {
   getCategoryBySlug,
@@ -17,6 +18,7 @@ import {
   getProducts,
 } from "@/lib/api";
 import { ALL_FILTER_SLUG } from "@/lib/filter";
+import { breadcrumbSchema } from "@/lib/structured-data";
 
 interface PageProps {
   params: Promise<{ category: string }>;
@@ -55,6 +57,10 @@ export async function generateMetadata({
     return {
       title: `${category.name} | INVITUS`,
       description: `Купуйте ${category.name.toLowerCase()} від INVITUS. Українська якість для пауерліфтингу та важкої атлетики.`,
+      // Query-less on purpose: ?filter= narrows the same catalog rather than
+      // producing a new page, so every filtered view points the index back at
+      // the bare category URL.
+      alternates: { canonical: `/shop/${categorySlug}` },
     };
   } catch {
     return {
@@ -81,6 +87,15 @@ async function CatalogContent({
 
   return (
     <>
+      {/* Inside Suspense because the category name only exists once this
+          resolves. It still lands in the streamed HTML response, so crawlers
+          see it without running any JS. */}
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Головна", path: "/" },
+          { name: category.name, path: `/shop/${category.slug}` },
+        ])}
+      />
       <PageHero title={`${category.name} (${products.length})`} />
       <CatalogGrid products={products} />
     </>

--- a/components/seo/json-ld.tsx
+++ b/components/seo/json-ld.tsx
@@ -1,0 +1,24 @@
+import type { JsonLdObject } from "@/lib/structured-data";
+
+interface JsonLdProps {
+  data: JsonLdObject | JsonLdObject[];
+}
+
+/**
+ * Emits a <script type="application/ld+json"> block. Server-rendered, so the
+ * markup is in the initial HTML and costs no client JS.
+ *
+ * `<` is escaped because product names and descriptions come from KeyCRM: a
+ * value containing "</script>" would otherwise close the tag early and inject
+ * whatever followed it into the page.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -41,6 +41,8 @@ const CATEGORY_SLUG_BY_ID: Record<number, string> = {
 // sitemap, featured lists and product pages. Filtered at the fetch layer so
 // every consumer is covered. To bring a category back, just remove its id.
 const HIDDEN_CATEGORY_IDS = new Set<number>([
+  5, // Додаткові товари — Браслет, Рушник, ID Card. Ціна 0, категорії немає в
+  //    навігації, а сторінки все одно віддавались і лежали в sitemap.
   6, // Футболки — поки немає в продажу
   7, // Службове (тест) — 0.50 ₴ товар для перевірки бойового еквайрингу
 ]);

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,180 @@
+// Schema.org JSON-LD builders.
+//
+// Ground rule: every statement here has to survive being checked against the
+// rendered page. Structured data that contradicts what a visitor sees is a
+// manual-action risk, not merely a wasted opportunity. Three consequences that
+// shaped what is — and is not — emitted below:
+//
+//   * No `aggregateRating` / `review`. There is no per-product rating data
+//     anywhere in the system. The video testimonials are brand-level and are
+//     not tied to a product, so they cannot stand in for one.
+//   * One price per product, `product.price` (KeyCRM `min_price`). That is both
+//     the number the catalog shows and the number lib/orders.ts actually
+//     charges, whichever size the customer picks — see the pricing note there.
+//   * No `sku`. Real SKUs live on the KeyCRM offers, i.e. one per size, while
+//     this markup describes the product. Picking one size's SKU to stand for
+//     the whole page would be a wrong identifier, which is worse than none.
+
+import { SITE_URL } from "./site";
+import { SHIPPING_COST } from "./shipping";
+import type { Product, ProductImage } from "@/types";
+
+/** A JSON-LD node. Loose by design — schema.org shapes are open-ended. */
+export type JsonLdObject = Record<string, unknown>;
+
+const BRAND_NAME = "INVITUS";
+const CURRENCY = "UAH";
+const COUNTRY = "UA";
+const INSTAGRAM_URL = "https://instagram.com/invitus.ua";
+const SUPPORT_EMAIL = "invitus.ua@gmail.com";
+
+// The coral brand mark from public/. Google wants a logo it can fetch; the
+// header wordmark is live text, so this is the only raster brand asset there is.
+const LOGO_PATH = "/android-chrome-512x512.png";
+
+/**
+ * Site-relative paths become absolute against the canonical origin; KeyCRM and
+ * Strapi image URLs are already absolute and pass through untouched.
+ */
+function absolute(pathOrUrl: string): string {
+  return /^https?:\/\//i.test(pathOrUrl)
+    ? pathOrUrl
+    : new URL(pathOrUrl, `${SITE_URL}/`).toString();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Organization
+// ──────────────────────────────────────────────────────────────────────────
+
+export function organizationSchema(): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": `${SITE_URL}/#organization`,
+    name: BRAND_NAME,
+    url: `${SITE_URL}/`,
+    logo: absolute(LOGO_PATH),
+    description:
+      "Український бренд екіпірування для пауерліфтингу: атлетичні пояси, кистьові бинти, наколінники та лямки.",
+    sameAs: [INSTAGRAM_URL],
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "customer support",
+      email: SUPPORT_EMAIL,
+      areaServed: COUNTRY,
+      availableLanguage: ["uk"],
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Offer sub-nodes
+// ──────────────────────────────────────────────────────────────────────────
+
+/** Mirrors the three promises rendered on /refund — see content/refund.ts. */
+function merchantReturnPolicy(): JsonLdObject {
+  return {
+    "@type": "MerchantReturnPolicy",
+    applicableCountry: COUNTRY,
+    returnPolicyCategory: "https://schema.org/MerchantReturnFiniteReturnWindow",
+    merchantReturnDays: 14,
+    returnMethod: "https://schema.org/ReturnByMail",
+    // "Зворотня пересилка Новою поштою — повністю за наш рахунок"
+    returnFees: "https://schema.org/FreeReturn",
+  };
+}
+
+/** The flat Nova Poshta rate the checkout adds to every order. */
+function offerShippingDetails(): JsonLdObject {
+  return {
+    "@type": "OfferShippingDetails",
+    shippingRate: {
+      "@type": "MonetaryAmount",
+      value: SHIPPING_COST,
+      currency: CURRENCY,
+    },
+    shippingDestination: {
+      "@type": "DefinedRegion",
+      addressCountry: COUNTRY,
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Product
+// ──────────────────────────────────────────────────────────────────────────
+
+export function productSchema(
+  product: Product,
+  categoryName?: string
+): JsonLdObject {
+  const url = absolute(`/product/${product.slug}`);
+
+  const images = [
+    product.mainImage,
+    product.heroImage,
+    ...(product.galleryImages ?? []),
+  ]
+    .filter((image): image is ProductImage => Boolean(image?.url))
+    .map((image) => absolute(image.url));
+
+  const schema: JsonLdObject = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.name,
+    url,
+    brand: { "@type": "Brand", name: BRAND_NAME },
+  };
+
+  const uniqueImages = [...new Set(images)];
+  if (uniqueImages.length) schema.image = uniqueImages;
+  if (product.description) schema.description = product.description;
+  if (categoryName) schema.category = categoryName;
+
+  // Three KeyCRM entries in "Додаткові товари" (Браслет, Рушник, ID Card) carry
+  // a price of 0 yet still render as product pages and sit in the sitemap. An
+  // Offer priced at 0 reads as "free" and is rejected as a merchant listing, so
+  // those pages describe the product and stop short of claiming a price.
+  if (product.price > 0) {
+    schema.offers = {
+      "@type": "Offer",
+      url,
+      price: product.price,
+      priceCurrency: CURRENCY,
+      itemCondition: "https://schema.org/NewCondition",
+      // Deliberately not derived from KeyCRM stock. Nothing in the UI gates on
+      // it — the size selector offers every size and the order path never
+      // checks quantity — so "in stock" is what a visitor actually finds. The
+      // day stock gating lands, this has to start following it.
+      availability: "https://schema.org/InStock",
+      seller: { "@type": "Organization", "@id": `${SITE_URL}/#organization` },
+      hasMerchantReturnPolicy: merchantReturnPolicy(),
+      shippingDetails: offerShippingDetails(),
+    };
+  }
+
+  return schema;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Breadcrumbs
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface BreadcrumbItem {
+  name: string;
+  /** Site-relative path, e.g. "/shop/belts". */
+  path: string;
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absolute(item.path),
+    })),
+  };
+}

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -131,10 +131,10 @@ export function productSchema(
   if (product.description) schema.description = product.description;
   if (categoryName) schema.category = categoryName;
 
-  // Three KeyCRM entries in "Додаткові товари" (Браслет, Рушник, ID Card) carry
-  // a price of 0 yet still render as product pages and sit in the sitemap. An
-  // Offer priced at 0 reads as "free" and is rejected as a merchant listing, so
-  // those pages describe the product and stop short of claiming a price.
+  // An Offer priced at 0 reads as "free" and is rejected as a merchant listing.
+  // The category that held every such entry ("Додаткові товари") is hidden in
+  // lib/api.ts, so nothing should reach this branch today — it stays as a guard
+  // for the next KeyCRM item that arrives without a price.
   if (product.price > 0) {
     schema.offers = {
       "@type": "Offer",


### PR DESCRIPTION
The site served **zero** structured data — verified against production: no
`ld+json` on the homepage, on `/product/zeus-lifting-belt` or on `/shop/belts` —
and declared no canonical at all, so `?filter=` views, the `vercel.app` alias and
every preview deploy were separately indexable copies of the same catalog.

## Canonicals

Declared per page, never at the root layout: metadata is inherited by any
segment that does not override it, so one canonical at the root would name the
homepage as the canonical of the entire site. Confirmed on a dev server that
`/shop/belts?filter=powerlifting` now points the index at bare `/shop/belts`.

## Structured data, claiming only what the page can be checked against

- **No `aggregateRating` / `review`.** There is no per-product rating data
  anywhere, and the video testimonials are brand-level, not per product.
  Inventing one is a policy violation with manual actions attached.
- **One price**, `product.price` (KeyCRM `min_price`) — the number the catalog
  shows *and* the number `lib/orders.ts` actually charges whatever size is
  picked. Per-variant offers would have contradicted the checkout, and a price
  mismatch is exactly what Google penalises.
- **No `sku`.** Real SKUs are per size; one size's SKU standing for the whole
  page would be a wrong identifier rather than a missing one.
- **`availability` is InStock unconditionally**, because nothing in the UI or
  the order path gates on stock — the size selector offers every size and
  pricing never checks quantity. That is what a visitor actually finds. Noted at
  the call site that it must start following stock the day gating lands.
- Return policy (14 days, free return by mail) and the flat 120 ₴ shipping rate
  are real, from `content/refund.ts` and `lib/shipping.ts`, so both are
  declared — they are what Google wants for merchant listings.

## Second commit: "Додаткові товари" out of the index

`Браслет`, `Рушник` and `ID Card` sat in a category that appears nowhere in the
navigation, carried a price of 0, and still rendered product pages listed in
`sitemap.xml`. Hiding category 5 the way 6 and 7 are hidden takes them out of the
catalog, the sitemap and the routes at once — 31 indexable products become 28.

Hiding it exposed a second problem it would otherwise have hit:
`/shop/dodatkovi-tovary` kept answering **200**. `notFound()` was called inside
`<Suspense>`, and by the time that boundary resolves the 200 is already on the
wire — so the not-found screen rendered under a success status, a soft 404
Google keeps indefinitely. The category is now resolved in the page component
before the shell streams; only the small cached category list is awaited and the
slow products fetch stays behind the skeleton. **Every** unknown category slug
now answers 404, not just this one.

## Verified

| | |
|---|---|
| `/shop/belts?filter=…` | canonical `/shop/belts` |
| `/shop/dodatkovi-tovary` | 404 (was 200) |
| `/shop/nonsense-slug` | 404 (was 200) |
| `/product/braslet` | 404 |
| prerendered product pages | 28, matching KeyCRM after hiding 5/6/7 |

`tsc` and `pnpm build` clean.

## Not fixed here

**No product has a description in KeyCRM** — 0 of 28. So every product page also
ships without a meta description, and the Product node omits `description`.
That is content work, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)