### PR TITLE
Site polish: canonical socials, related-products CTA, clipped check icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,17 @@ Next.js 16 App Router application for INVITUS — a Ukrainian powerlifting equip
 - **Online payments** — `paymentMethod === "online"` redirects through Monobank acquiring. Client → `app/api/orders` → Monobank → `app/payment-result` (status check + cart clear on success). Server-side client in `lib/monobank.ts`. Requires `MONOBANK_TOKEN` in `.env.local` (server-only). Status endpoint at `app/api/monobank/status`. Test tokens available at https://api.monobank.ua/.
 
 Pexels api key - AQT9iudesPqlSQYM2L4gVI39ypXc07BTJUNOmNAEk5Nk73bLn5LyPiz6
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `yegoshua/invitus`, managed with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/app/payment-result/page.tsx
+++ b/app/payment-result/page.tsx
@@ -17,9 +17,8 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic";
 
 const socialLinks = [
-  { href: "https://instagram.com/invitus.ua", label: "Instagram" },
-  { href: "https://t.me/invitus_ua", label: "Telegram" },
-  { href: "https://tiktok.com/@invitus.ua", label: "TikTok" },
+  { href: "https://www.instagram.com/invitus.ua", label: "Instagram" },
+  { href: "https://www.tiktok.com/@invitus.ua", label: "TikTok" },
 ];
 
 interface PageProps {
@@ -173,7 +172,7 @@ function SuccessCard() {
       <p className="mt-6 lg:mt-8 font-sans font-medium text-[14px] leading-5 tracking-[0.01em] text-[#FFFFFFA3]">
         Щось пішло не так із замовленням? Напиши нам у{" "}
         <a
-          href="https://instagram.com/invitus.ua"
+          href="https://www.instagram.com/invitus.ua"
           target="_blank"
           rel="noopener noreferrer"
           className="text-white hover:text-coral transition-colors underline underline-offset-2"

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -87,7 +87,10 @@ export default async function ProductPage({ params }: Props) {
       <Header />
       <ProductPageContent product={product} />
       <ProductImagesSection images={product.galleryImages || []} />
-      <RelatedProducts products={relatedProducts} />
+      <RelatedProducts
+        products={relatedProducts}
+        categorySlug={category?.slug}
+      />
       <FAQSection />
       <BenefitsGrid />
       <Footer />

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -10,8 +10,8 @@ const categoryLinks = [
 ];
 
 const socialLinks = [
-  { href: "https://instagram.com/invitus.ua", label: "Instagram" },
-  { href: "https://tiktok.com/@invitus.ua", label: "TikTok" },
+  { href: "https://www.instagram.com/invitus.ua", label: "Instagram" },
+  { href: "https://www.tiktok.com/@invitus.ua", label: "TikTok" },
 ];
 
 const legalLinks = [

--- a/components/product/related-products.tsx
+++ b/components/product/related-products.tsx
@@ -3,14 +3,16 @@ import type { Product } from "@/types";
 
 interface RelatedProductsProps {
   products?: Product[];
+  /** Category slug of the product being viewed — the CTA points at its catalog page. */
+  categorySlug?: string;
 }
 
-export function RelatedProducts({ products }: RelatedProductsProps) {
+export function RelatedProducts({ products, categorySlug }: RelatedProductsProps) {
   return (
     <ProductRow
       products={products}
       title="Твій фул-сет тут"
-      ctaHref="/shop/belts"
+      ctaHref={`/shop/${categorySlug ?? "belts"}`}
       ctaLabel="ЧЕКНУТИ УСЕ"
       className="pt-20 lg:pt-32"
       titleClassName="text-left lg:text-center mb-10 lg:mb-20"

--- a/components/refund/refund-process.tsx
+++ b/components/refund/refund-process.tsx
@@ -47,11 +47,13 @@ export function RefundProcess() {
             <FadeUp
               key={condition.title}
               delay={index * 0.1}
-              className="bg-surface rounded-3xl p-6 lg:p-10 flex items-center gap-4 lg:gap-6"
+              className="bg-surface rounded-3xl p-6 lg:p-10 flex items-start lg:items-center gap-4 lg:gap-6"
             >
-              <CheckIcon className="w-7 h-7 lg:w-8 lg:h-8 shrink-0" />
-              <div>
-                <h3 className="font-heading text-2xl leading-8 tracking-[0.02em] font-bold text-white mb-2 lg:mb-3">
+              {/* mt keeps the icon on the first line of the title while the card is top-aligned */}
+              <CheckIcon className="w-7 h-7 lg:w-8 lg:h-8 shrink-0 mt-0.5 lg:mt-0" />
+              {/* min-w-0 lets the column shrink; long Ukrainian words otherwise push past the card padding */}
+              <div className="min-w-0">
+                <h3 className="font-heading text-2xl leading-8 tracking-[0.02em] font-bold text-white mb-2 lg:mb-3 break-words">
                   {condition.title}
                 </h3>
                 <p className="text-white font-medium text-xl leading-7 tracking-[0.01em]">

--- a/content/navigation.ts
+++ b/content/navigation.ts
@@ -13,7 +13,6 @@ export const navLinks: NavLink[] = [
 ];
 
 export const socialLinks: NavLink[] = [
-  { href: "https://instagram.com/invitus_ua", label: "Instagram" },
-  { href: "https://t.me/invitus_ua", label: "Telegram" },
-  { href: "https://tiktok.com/@invitus_ua", label: "TikTok" },
+  { href: "https://www.instagram.com/invitus.ua", label: "Instagram" },
+  { href: "https://www.tiktok.com/@invitus.ua", label: "TikTok" },
 ];

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+**This repo is single-context** — one `CONTEXT.md` and one `docs/adr/` at the root. Neither exists yet; that's expected, and per the rule above you should proceed silently rather than flag it.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-orders-priced-server-side.md
+│   └── 0002-product-content-split-keycrm-strapi.md
+└── app/ components/ lib/ …
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -25,7 +25,7 @@ export type JsonLdObject = Record<string, unknown>;
 const BRAND_NAME = "INVITUS";
 const CURRENCY = "UAH";
 const COUNTRY = "UA";
-const INSTAGRAM_URL = "https://instagram.com/invitus.ua";
+const INSTAGRAM_URL = "https://www.instagram.com/invitus.ua";
 const SUPPORT_EMAIL = "invitus.ua@gmail.com";
 
 // The coral brand mark from public/. Google wants a logo it can fetch; the

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,23 @@ const nextConfig: NextConfig = {
   turbopack: {
     rules: {
       "**/assets/icons/**/*.svg": {
-        loaders: ["@svgr/webpack"],
+        loaders: [
+          {
+            loader: "@svgr/webpack",
+            options: {
+              // svgo drops viewBox whenever width/height are present. Without it
+              // an icon sized by CSS (w-7 on a 32-unit grid) is clipped, not scaled.
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: "preset-default",
+                    params: { overrides: { removeViewBox: false } },
+                  },
+                ],
+              },
+            },
+          },
+        ],
         as: "*.js",
       },
     },


### PR DESCRIPTION
Four unrelated fixes that had accumulated in the working tree, split into one commit each.

### Canonical social links
Three files listed socials and had drifted apart — two spelled the handle `invitus_ua`, two `invitus.ua`, and only `payment-result` still carried Telegram. Both platforms 301 the bare host to `www`, so every click paid a redirect and the JSON-LD `sameAs` pointed at a non-canonical URL. Telegram is dropped rather than fixed: `t.me/invitus_ua` does not exist.

### Related-products CTA
The row shows category-mates of the product being viewed, but "ЧЕКНУТИ УСЕ" was hardcoded to `/shop/belts`. From a knee sleeve it offered four knee sleeves and then a link to the belt catalog. Now follows the row's own category.

### Clipped check icons
`svgo`'s `preset-default` strips `viewBox` when width/height are present, so an icon sized by CSS (`w-7` against a 32-unit grid) rendered cropped instead of scaled. `removeViewBox: false` in the SVGR loader options fixes it globally for `assets/icons/**`.

The refund cards also switch to top alignment — centring only worked while every title fit one line — and `min-w-0` lets the text column shrink so long Ukrainian words wrap inside the card padding.

### Agent conventions
Issue tracking, triage labels and domain-doc layout were tribal knowledge passed between sessions; written into `docs/agents/`.

---

**Deliberately left out of this PR:** a working-tree change to `components/checkout/order-summary.tsx` that replaced the delivery line "від 200 ₴" with "Тарифи оператора" while `total` still adds `SHIPPING_COST`. That shows the customer two figures that don't add up and charges an unexplained extra. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtFKZ6x3odmjjTWyScUTY1