### PR TITLE
content: checkout says "тарифи оператора" instead of a shipping figure

### DIFF
--- a/components/checkout/order-summary.tsx
+++ b/components/checkout/order-summary.tsx
@@ -82,9 +82,7 @@ export function OrderSummary({
         </div>
         <div className="flex justify-between items-baseline mt-2 text-base leading-6 font-medium tracking-[0.01em] text-white">
           <span>Доставка</span>
-          <span className="font-medium">
-            від {SHIPPING_COST} ₴
-          </span>
+          <span className="font-medium">Тарифи оператора</span>
         </div>
         <div className="flex justify-between items-baseline mt-4">
           <span className="font-heading font-bold text-base leading-6 tracking-[0.05em] uppercase text-white">


### PR DESCRIPTION
## Що

Рядок «Доставка» у зведенні замовлення показував `від 120 ₴`. Тепер — `Тарифи оператора`, як і підказка під вибором відділення (`delivery-fields.tsx:134`), яка вже казала «Доставляємо Новою поштою — тарифи оператора».

Зміна суто текстова: один рядок у `components/checkout/order-summary.tsx`.

## ⚠️ Що НЕ змінилось — і це видно покупцеві

`SHIPPING_COST` (120 ₴) досі:

- додається до «ДО ОПЛАТИ» на клієнті (`order-summary.tsx:28`, `checkout-page.tsx:93`),
- списується сервером — `lib/orders.ts:108` кладе його в `shipping_price` замовлення KeyCRM і в суму інвойсу Monobank,
- віддається як `OfferShippingDetails.shippingRate` у structured data (`lib/structured-data.ts:93`).

Тобто на живій сторінці зараз так (перевірено на `/checkout` з товаром у кошику):

```
Замовлення        4 200 ₴
Доставка          Тарифи оператора
ДО ОПЛАТИ:        4 320 ₴
```

120 ₴ у тоталі більше нічим не підписані. Це свідоме рішення для цього PR (міняємо лише напис), але його варто закрити наступним кроком — або повернути суму в рядок, або перестати її брати і прибрати з `lib/orders.ts` + structured data.

## Перевірка

- `npx tsc --noEmit` — чисто
- `pnpm lint` — чисто (зауваження: `pnpm type-check` з CLAUDE.md у package.json відсутній)
- Ручна перевірка `/checkout` у 1440px і 390px — напис вміщується в один рядок в обох макетах (десктопний sticky-сайдбар і мобільний нижній блок)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtFKZ6x3odmjjTWyScUTY1