### PR TITLE
perf: testimonials video waits for the viewport

### DIFF
--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -10,6 +10,7 @@ import {
 import { motion } from "framer-motion";
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useVideoGate } from "@/hooks/use-video-gate";
 import { testimonials } from "@/content/testimonials";
 
 // Start centered on the middle card, whatever the number of testimonials
@@ -28,6 +29,14 @@ export function TestimonialsSection() {
   const [isMuted, setIsMuted] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
+
+  // The gate watches the section rather than any one card: the carousel keeps
+  // deciding which video plays, and this only decides whether any of them
+  // exist yet. `preload="metadata"` was already here and was already right —
+  // what defeated it was the effect below calling play() at mount, which
+  // pulled the whole selected file down while the visitor was still on the
+  // hero.
+  const { ref: sectionRef, shouldLoad, isInView } = useVideoGate<HTMLElement>();
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 1280);
@@ -72,19 +81,24 @@ export function TestimonialsSection() {
     () => START_INDEX
   );
 
-  // Manage video playback - only play the selected video
+  // Manage video playback - only play the selected video, and only while the
+  // section is on screen
   useEffect(() => {
+    if (!shouldLoad) return;
+
     videoRefs.current.forEach((video, index) => {
       if (video) {
-        if (index === selectedIndex) {
+        if (index === selectedIndex && isInView) {
           video.play().catch(() => {});
         } else {
           video.pause();
-          video.currentTime = 0;
+          // Rewinding only the ones that are not selected: scrolling past the
+          // section and back should resume the story, not restart it.
+          if (index !== selectedIndex) video.currentTime = 0;
         }
       }
     });
-  }, [selectedIndex]);
+  }, [selectedIndex, shouldLoad, isInView]);
 
   const toggleMute = () => {
     setIsMuted(!isMuted);
@@ -96,7 +110,7 @@ export function TestimonialsSection() {
   };
 
   return (
-    <section className="bg-black pt-20 lg:pt-45 overflow-hidden">
+    <section ref={sectionRef} className="bg-black pt-20 lg:pt-45 overflow-hidden">
       <div className="container-main">
         {/* Heading */}
         <motion.div
@@ -140,7 +154,7 @@ export function TestimonialsSection() {
                       ref={(el) => {
                         videoRefs.current[index] = el;
                       }}
-                      src={testimonial.video}
+                      src={shouldLoad ? testimonial.video : undefined}
                       className="absolute inset-0 w-full h-full object-cover"
                       loop
                       muted={isMuted}
@@ -148,8 +162,9 @@ export function TestimonialsSection() {
                       preload="metadata"
                     />
 
-                    {/* Mute button - only on selected */}
-                    {isSelected && (
+                    {/* Mute button - only on the selected card, and only when
+                        there is something to mute */}
+                    {isSelected && shouldLoad && (
                       <button
                         onClick={toggleMute}
                         className="absolute bottom-6 right-6 z-20 cursor-pointer"

--- a/docs/perf/lighthouse.md
+++ b/docs/perf/lighthouse.md
@@ -158,3 +158,40 @@ exactly one once the section is approached, buffered to `readyState 4` and
 playing before it is on screen; paused after scrolling past and playing again on
 the way back; and under `prefers-reduced-motion: reduce` no request at all, with
 the section keeping its 500 px box and dropping its mute button.
+
+## After #41 — the testimonials carousel waits too
+
+| Metric | Baseline | After #38 | After #41 |
+| --- | --- | --- | --- |
+| Performance score | 82 | 85 | 85 |
+| LCP | 4.84 s | 4.29 s | 4.29 s |
+| Transfer before `load` | 36.94 MiB | 18.27 MiB | **10.02 MiB** |
+| Transfer, whole run | 36.95 MiB | 19.69 MiB | **11.75 MiB** |
+| Speed Index | 2.29 s | 2.28 s | 2.12 s |
+| CLS | 0 | 0 | 0 |
+
+The three testimonial files are 0.6, 9.0 and 3.3 MB, and `START_INDEX` lands on
+the 9.0 MB one — which is why one section accounted for most of what the gate
+lost here.
+
+What is left before `load` is now almost entirely one file:
+
+| | starts | transferred |
+| --- | --- | --- |
+| `belt-benefits-section-video-scrub.webm` | 51 ms | **9.52 MiB** |
+| the three.js chunk | 163 ms | 0.27 MiB |
+| `hero-section.mp4` | 147 ms | 1.41 MiB — *after* the load event at 120 ms, so outside the gate |
+
+So the transfer gate is one ticket away from budget: [#42](https://github.com/yegoshua/invitus/issues/42)
+takes the scrub off the load path, and [#39](https://github.com/yegoshua/invitus/issues/39)
+takes the three.js chunk. Note that this run captured the scrub **once**, not
+twice — the second copy is a `fetch(...).blob()` from an effect and lands at
+different points in different traces, which is another reason #42 should assert
+the request count in a network trace rather than infer it from the total.
+
+Behaviour, again checked in headless Chrome rather than by the budget: zero
+requests for any testimonial at load; three once the section is approached, of
+which only the selected one plays; the Next arrow moves playback with the
+selection; the mute control still mutes all three, as it did before; playback
+pauses on the way past and resumes — on the same card, not from the start — on
+the way back.


### PR DESCRIPTION
Closes #41. **Stacked on #53** — base it on `main` once that merges.

## What changed

The markup was already careful: `preload="metadata"` was there and was right. What defeated it was the effect beside it calling `play()` on the selected card at mount, which pulled the whole file down while the visitor was still on the hero. The three files are 0.6, 9.0 and 3.3 MB and `START_INDEX` lands on the 9.0 MB one, so one section accounted for most of the homepage's remaining weight.

`components/sections/testimonials-section.tsx` now hangs on `useVideoGate` from #38, watching the **section** rather than any one card — the carousel keeps deciding which video plays, the gate only decides whether any of them exist yet.

One behavioural addition beyond deferral: playback now follows the viewport. Off screen it stops; coming back it resumes the card the visitor left rather than restarting it (only the *non*-selected cards get rewound, which is what the original code did).

## Measured

`pnpm perf:lighthouse`, mobile, clean profile, median of 3:

| Metric | After #38 | After #41 |
| --- | --- | --- |
| Transfer before `load` | 18.27 MiB | **10.02 MiB** |
| Transfer, whole run | 19.69 MiB | **11.75 MiB** |
| Speed Index | 2.28 s | 2.12 s |
| LCP | 4.29 s | 4.29 s |
| CLS | 0 | 0 |

What is left before `load` is one file plus change: the belt scrub at 9.52 MiB (#42) and the three.js chunk at 0.27 MiB (#39). The hero's 1.41 MiB starts at 147 ms, after the load event at 120 ms, so it is correctly outside the gate.

Worth noting for #42: **this run captured the scrub once, not twice.** The second copy comes from a `fetch(...).blob()` in an effect and lands at different points in different traces — so #42 should assert the request count in a network trace rather than infer it from the total.

## Checked by hand

Headless Chrome via puppeteer, since the budget sees none of this:

- 0 requests for any testimonial at `load`
- 3 once the section is approached; only the selected one plays
- the Next arrow moves the selection and playback follows it
- the mute control still mutes all three, as before
- pauses on the way past, resumes the same card on the way back

## One thing to flag

Under `prefers-reduced-motion` or `save-data` the gate never attaches a source, so this section renders as three empty rounded boxes under its heading — same for the motivation section after #38. That follows #34's rule as written and the layout is intact, but it is not a good-looking degradation. Posters for the skipped state would fix both; filing separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)