### PR TITLE
perf: the catalog stops hiding the image it is judged by

### DIFF
--- a/components/sections/catalog-grid.tsx
+++ b/components/sections/catalog-grid.tsx
@@ -8,6 +8,12 @@ import type { Product } from "@/types";
 
 const LIST_NAME = "Каталог";
 
+// One desktop row (`lg:grid-cols-4`). On mobile the grid is a single column, so
+// this is more cards than are strictly visible — but they are ~30 KB thumbnails
+// and guessing the viewport on the server is not possible. Measured both ways;
+// see the note on #60.
+const ABOVE_THE_FOLD = 4;
+
 interface CatalogGridProps {
   products: Product[];
 }
@@ -39,15 +45,28 @@ export function CatalogGrid({ products }: CatalogGridProps) {
     <section className="bg-black">
       <div className="container-main">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-4 lg:gap-x-4 lg:gap-y-6">
-          {products.map((product, index) => (
-            <FadeUp key={product.id} duration={0.5} delay={(index % 4) * 0.1}>
+          {products.map((product, index) => {
+            const card = (
               <ProductCard
                 product={product}
                 index={index}
                 listName={LIST_NAME}
+                aboveTheFold={index < ABOVE_THE_FOLD}
               />
-            </FadeUp>
-          ))}
+            );
+
+            // The first row carries the LCP, so it is painted rather than
+            // animated in. `FadeUp` here wrapped a card that was *already*
+            // fading itself — two entrance animations stacked on the element
+            // the page is judged by.
+            return index < ABOVE_THE_FOLD ? (
+              <div key={product.id}>{card}</div>
+            ) : (
+              <FadeUp key={product.id} duration={0.5} delay={(index % 4) * 0.1}>
+                {card}
+              </FadeUp>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/components/ui/product-card.tsx
+++ b/components/ui/product-card.tsx
@@ -16,9 +16,25 @@ interface ProductCardProps {
   index?: number;
   /** Name of the list this card belongs to (correlates view_item_list ↔ select_item). */
   listName?: string;
+  /**
+   * This card is on screen before the visitor scrolls, so it is a candidate for
+   * the page's LCP. Its image is fetched eagerly and at high priority, and it
+   * does not fade in — both of which are the difference between an 8.4 s LCP
+   * and a fast one on the catalog (#60).
+   *
+   * Only pass it for cards genuinely in the first screenful. Every `priority`
+   * image is also a `<link rel=preload>`, and a page that preloads everything
+   * has prioritised nothing.
+   */
+  aboveTheFold?: boolean;
 }
 
-export function ProductCard({ product, index = 0, listName }: ProductCardProps) {
+export function ProductCard({
+  product,
+  index = 0,
+  listName,
+  aboveTheFold = false,
+}: ProductCardProps) {
   // For the visitor who never hovers — a phone, where the first contact with a
   // card is the tap itself. Owned by the card rather than by each grid, so a
   // new listing surface cannot forget it. Only the first card on a page
@@ -27,12 +43,20 @@ export function ProductCard({ product, index = 0, listName }: ProductCardProps) 
 
   const formattedPrice = formatPrice(product.price);
 
+  // A card that decides the LCP does not get to spend half a second being
+  // transparent first. Cards further down keep the entrance they always had.
+  const entrance = aboveTheFold
+    ? {}
+    : {
+        initial: { opacity: 0, y: 20 },
+        whileInView: { opacity: 1, y: 0 },
+        viewport: { once: true },
+        transition: { duration: 0.5, delay: index * 0.1 },
+      };
+
   return (
     <motion.article
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.5, delay: index * 0.1 }}
+      {...entrance}
       className="group md:flex-shrink-0 md:w-[318px] lg:w-auto"
     >
       <Link
@@ -56,6 +80,13 @@ export function ProductCard({ product, index = 0, listName }: ProductCardProps) 
             <ProductMedia
               image={product.mainImage}
               fill
+              // `priority` buys eager loading and a preload hint for the whole
+              // first row. The hint that says "this one before the others" goes
+              // to one card only — the top-left, which is the LCP element in
+              // both the one-column and the four-column layout. Next does not
+              // emit it by itself, and Lighthouse checks for it by name.
+              priority={aboveTheFold}
+              fetchPriority={aboveTheFold && index === 0 ? "high" : undefined}
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               className="object-cover transition-transform duration-500 group-hover:scale-105"
             />

--- a/docs/perf/lighthouse.md
+++ b/docs/perf/lighthouse.md
@@ -16,6 +16,9 @@ pnpm perf:lighthouse --runs 1            # one run instead of the median of thre
 pnpm perf:lighthouse --url /shop/belts   # a different page
 pnpm perf:lighthouse --label before       # names the saved report
 pnpm perf:lighthouse --port 4319         # if 4318 is taken
+pnpm perf:lighthouse --origin https://invitus.com.ua
+                                         # measure a real deployment: no build,
+                                         # no local server, just the CDN
 ```
 
 Reports are written to `perf/reports/<label>.html` and `.json` (git-ignored).
@@ -293,3 +296,36 @@ it. The LCP gate is still the open one, and #37's finding stands: with all media
 removed LCP still simulated at 3.95 s, so what remains is main-thread work under
 the 4× CPU multiplier rather than bytes. #43 is where that gets confronted
 against a real deployment instead of a simulation.
+
+
+## The catalog — #60
+
+The homepage was #34's whole scope, and the catalog turned out to be worse. Measured on `/shop/belts`, mobile, clean profile, median of 3:
+
+| | before | after |
+| --- | --- | --- |
+| Performance score | 77 | **84** |
+| LCP, simulated | 6.53 s | **4.59 s** |
+| LCP, observed in the trace | 0.94 s | **0.37 s** |
+| Resource load delay | 367 ms | **28 ms** |
+| Element render delay | 539 ms | **318 ms** |
+| Speed Index | 0.96 s | 0.90 s |
+| CLS | 0 | 0 |
+| Whole-run transfer | 0.87 MiB | 0.87 MiB |
+
+Nothing about this was bytes: the page is under a megabyte and the LCP image
+transferred in 8 ms. It was 367 ms of nobody asking for it — `loading="lazy"` on
+the element that decides the metric — plus 539 ms of it being transparent behind
+two stacked entrance animations, `FadeUp` wrapping a `ProductCard` that was
+already fading itself.
+
+All three of Lighthouse's LCP-discovery checks now pass. `fetchpriority=high`
+had to be set by hand: `priority` on next/image buys eager loading and a preload
+hint but does not emit the attribute Lighthouse looks for. It goes to **one**
+card, the top-left, which is the LCP element in both the one-column and the
+four-column layout; the rest of the first row gets `priority` without it, because
+a page that prioritises everything has prioritised nothing.
+
+The simulated figure is still over the 2.5 s gate and, as on the homepage, that
+is the 4× CPU multiplier rather than the page: production scored 97 on a
+homepage this harness put at 86. Confirm on the deployment with `--origin`.

--- a/scripts/perf/lighthouse.mjs
+++ b/scripts/perf/lighthouse.mjs
@@ -7,6 +7,9 @@
  *   pnpm perf:lighthouse --skip-build measure the existing .next build
  *   pnpm perf:lighthouse --runs 1     one run instead of the median of three
  *   pnpm perf:lighthouse --label baseline-main  name the saved report
+ *   pnpm perf:lighthouse --origin https://invitus.com.ua
+ *                                     measure a real deployment instead of a
+ *                                     local build — no build, no local server
  *
  * Chrome is launched by chrome-launcher into a throwaway user-data-dir with
  * extensions disabled, so the numbers describe the site and nothing else.
@@ -48,20 +51,28 @@ try {
 }
 
 const port = args.port ?? 4318;
-const url = `http://localhost:${port}${args.url ?? budget.url ?? "/"}`;
+const path = args.url ?? budget.url ?? "/";
+// A deployment measures the CDN, TLS and the real TTFB; a local build measures
+// none of them and is therefore optimistic. `docs/perf/lighthouse.md` says to
+// iterate locally and confirm remotely, and #43 requires the remote half.
+const url = args.origin ? `${args.origin}${path}` : `http://localhost:${port}${path}`;
 
 let server;
 let chrome;
 
 try {
-  if (!args.skipBuild) {
+  if (!args.skipBuild && !args.origin) {
     console.log("→ building for production");
     const build = spawnSync("pnpm", ["build"], { cwd: ROOT, stdio: "inherit" });
     if (build.status !== 0) throw new Error("production build failed");
   }
 
-  console.log(`→ serving on port ${port}`);
-  server = await startServer(port);
+  if (args.origin) {
+    console.log(`→ measuring the deployment at ${args.origin} (nothing built or served locally)`);
+  } else {
+    console.log(`→ serving on port ${port}`);
+    server = await startServer(port);
+  }
 
   chrome = await chromeLauncher.launch({ chromeFlags: CHROME_FLAGS });
 
@@ -219,6 +230,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--url") args.url = argv[++i];
     else if (argv[i] === "--label") args.label = argv[++i];
     else if (argv[i] === "--runs") args.runs = Number(argv[++i]);
+    else if (argv[i] === "--origin") args.origin = argv[++i].replace(/\/$/, "");
     else throw new Error(`unknown argument: ${argv[i]}`);
   }
   return args;


### PR DESCRIPTION
Closes #60.

## What was wrong

The catalog had the worst LCP on the site — **8.4 s on production**, 6.5 s in the harness — on the *lightest* page on the site. Under a megabyte, Speed Index under a second, CLS 0, and the image that decides the metric transferring in 8 ms.

Two causes, neither of them bytes:

1. **`loading="lazy"` on the LCP element.** 367 ms passed before the browser was allowed to ask for it. Lighthouse failed all three of its LCP-discovery checks on it.
2. **Two stacked entrance animations.** `FadeUp` in `CatalogGrid` wrapped a `ProductCard` that was already a fading `motion.article` — so the element the page is graded by spent another 539 ms transparent.

## What changed

`ProductCard` gains one prop, `aboveTheFold`, covering both causes because they are the same concern: the first screenful does not get to delay itself. When set, the image loads eagerly and the card paints rather than fades. `CatalogGrid` passes it for the first row and skips the redundant `FadeUp` there; everything below is untouched.

`fetchpriority=high` is set by hand and only on the **first** card. `priority` on next/image buys eager loading and a preload hint but does not emit the attribute Lighthouse looks for — and the top-left card is the LCP element in both the one-column mobile layout and the four-column desktop one. The rest of the row gets `priority` without the hint, because a page that prioritises everything has prioritised nothing.

The homepage rows and related-products rails pass nothing, so they are unchanged — they sit below the fold, where lazy is correct.

## Measured

`pnpm perf:lighthouse --url /shop/belts`, mobile, clean profile, median of 3:

| | before | after |
| --- | --- | --- |
| Performance score | 77 | **84** |
| LCP, simulated | 6.53 s | **4.59 s** |
| LCP, observed in the trace | 0.94 s | **0.37 s** |
| Resource load delay | 367 ms | **28 ms** |
| Element render delay | 539 ms | **318 ms** |
| Speed Index | 0.96 s | 0.90 s |
| CLS | 0 | 0 |
| Whole-run transfer | 0.87 MiB | 0.87 MiB |

Verified in the rendered markup at both widths: card 1 is `eager` + `fetchpriority="high"` + `opacity: 1`, cards 2–4 are `eager` + `opacity: 1`, card 5 onward is still `loading="lazy"` and still fades in.

The simulated figure is over the 2.5 s gate that #60 asks for, and — as on the homepage — that is the 4× CPU multiplier rather than the page. The same harness put the homepage at 86 while production scores **97** in a clean incognito profile. This wants confirming on the deployment, which the first commit makes possible.

## Also in here

`pnpm perf:lighthouse --origin https://invitus.com.ua` — its own commit. `docs/perf/lighthouse.md` has always said to iterate locally and confirm remotely, but the script could only build and serve on localhost, so the "confirm" half had nothing to run. #43 needs it too.

## Found while measuring, filed not fixed

- **A pre-existing CLS of 0.2515 on `/shop/knee-sleeves`** — `CatalogSkeleton` always renders 8 placeholder cards regardless of how many products the category has, so on short categories everything below the grid jumps when the real one streams in. Confirmed byte-identical on `main` before this change, so it is not a regression here.
- **The `sizes` attribute is wrong for the catalog layout** — it claims `50vw` on mobile, but `CatalogGrid` is a single column, so the image renders at ~100vw and is served at roughly half the resolution it needs.

Both filed separately rather than bundled: the first is a layout bug, the second would *increase* bytes and muddy this PR's measurement.

`pnpm lint`, `pnpm type-check`, `pnpm test` (62) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)