### PR TITLE
fix: analytics events fired on first paint are queued, not dropped

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "invitus-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    },
+    {
+      "name": "invitus-wt38-prod",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--dir",
+        "/Users/yegor-nextcode/Invitus/web/invitus-wt-38",
+        "start",
+        "-p",
+        "3100"
+      ],
+      "port": 3100
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ next-env.d.ts
 
 # lighthouse reports (see perf/budget.json)
 /perf/reports/
+
+# browser tool output
+/.playwright-mcp/
+
+# per-user Claude Code permissions (launch.json is shared)
+/.claude/settings.local.json

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -7,23 +7,44 @@ const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 // dev/localhost gating in ClarityAnalytics so local dev never pollutes stats.
 // SPA route changes are captured by GA4 Enhanced Measurement (on by default),
 // which tracks History API navigations that Next.js App Router uses.
+//
+// The two halves are loaded deliberately differently, and swapping either one
+// back breaks something:
+//
+//   - The queue stub is a plain <script>, NOT next/script. In the App Router,
+//     `strategy="afterInteractive"` does not put the tag in the server HTML at
+//     all — it lives in the RSC payload and this component injects it from an
+//     effect. React runs effects child-first, and <GoogleAnalytics> is the last
+//     child of <body>, so every mount effect under {children} had already run
+//     and found window.gtag undefined. trackEvent silently no-ops when it does,
+//     so first-commit events were dropped on every cold load: view_item,
+//     view_item_list, and — the expensive one — the `purchase` on
+//     /payment-result, which is the ONLY place an online sale is ever counted.
+//     A plain inline script runs during HTML parse, so the queue always exists
+//     before hydration.
+//
+//   - gtag.js itself stays afterInteractive. It is ~90 KB and nothing needs it
+//     early: it replays whatever is already in window.dataLayer when it loads.
+//     Making it beforeInteractive would buy nothing and cost the perf budget.
 export function GoogleAnalytics() {
   if (!GA_ID || process.env.NODE_ENV !== "production") return null;
 
   return (
     <>
+      <script
+        id="ga-init"
+        dangerouslySetInnerHTML={{
+          __html:
+            `window.dataLayer=window.dataLayer||[];` +
+            `function gtag(){dataLayer.push(arguments);}` +
+            `gtag('js',new Date());` +
+            `gtag('config','${GA_ID}');`,
+        }}
+      />
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
         strategy="afterInteractive"
       />
-      <Script id="ga-init" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${GA_ID}');
-        `}
-      </Script>
     </>
   );
 }

--- a/lib/gtag.test.ts
+++ b/lib/gtag.test.ts
@@ -1,0 +1,86 @@
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { trackEvent } from "./gtag.ts";
+
+interface FakeWindow {
+  gtag?: (...args: unknown[]) => void;
+  dataLayer?: unknown[];
+}
+
+function withWindow(win: FakeWindow) {
+  (globalThis as { window?: FakeWindow }).window = win;
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: FakeWindow }).window;
+});
+
+test("sends through window.gtag once gtag.js has defined it", () => {
+  const calls: unknown[][] = [];
+  withWindow({ gtag: (...args) => calls.push(args) });
+
+  trackEvent("purchase", {
+    transaction_id: "1021",
+    value: 4920,
+    items: [],
+  });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0][0], "event");
+  assert.deepEqual(calls[0][1], "purchase");
+  assert.deepEqual(calls[0][2], {
+    currency: "UAH",
+    transaction_id: "1021",
+    value: 4920,
+    items: [],
+  });
+});
+
+// The regression. A first-commit mount effect — view_item, view_item_list, and
+// the purchase on /payment-result — runs before gtag.js has defined window.gtag.
+// trackEvent used to return silently there, so the ONE online sale the site
+// took was never counted while both cash-on-delivery sales were. Queueing means
+// the event waits for gtag.js instead of disappearing.
+test("queues into dataLayer when window.gtag does not exist yet", () => {
+  const dataLayer: unknown[] = [];
+  withWindow({ dataLayer });
+
+  trackEvent("purchase", {
+    transaction_id: "1021",
+    value: 4920,
+    items: [],
+  });
+
+  assert.equal(dataLayer.length, 1);
+
+  // gtag.js only recognises a queued command by its Arguments shape — an array
+  // would be dropped on the floor by the very library meant to replay it.
+  const queued = dataLayer[0] as IArguments;
+  assert.equal(Object.prototype.toString.call(queued), "[object Arguments]");
+  assert.equal(queued.length, 3);
+  assert.equal(queued[0], "event");
+  assert.equal(queued[1], "purchase");
+  assert.deepEqual(queued[2], {
+    currency: "UAH",
+    transaction_id: "1021",
+    value: 4920,
+    items: [],
+  });
+});
+
+test("prefers gtag over the queue when both are available", () => {
+  const dataLayer: unknown[] = [];
+  const calls: unknown[][] = [];
+  withWindow({ dataLayer, gtag: (...args) => calls.push(args) });
+
+  trackEvent("add_to_cart", { value: 2100, items: [] });
+
+  assert.equal(calls.length, 1);
+  assert.equal(dataLayer.length, 0);
+});
+
+test("does not throw when GA is absent from the build entirely", () => {
+  withWindow({});
+  assert.doesNotThrow(() => trackEvent("view_cart", { value: 0, items: [] }));
+});

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -58,19 +58,52 @@ type GtagFn = (
   params?: Record<string, unknown>
 ) => void;
 
+interface GAWindow {
+  gtag?: GtagFn;
+  dataLayer?: unknown[];
+}
+
+/**
+ * The official gtag() snippet, re-declared here.
+ *
+ * Pushes `arguments` and not an array on purpose: gtag.js recognises a queued
+ * command by that shape, and a plain `["event", …]` is ignored.
+ */
+function queueCommand(this: void): void {
+  // eslint-disable-next-line prefer-rest-params
+  (window as unknown as { dataLayer: unknown[] }).dataLayer.push(arguments);
+}
+
+/**
+ * Never reached in the normal case — the inline stub in <GoogleAnalytics>
+ * defines window.gtag during HTML parse. It is the safety net for the failure
+ * that actually happened: when window.gtag did not exist yet this function
+ * silently returned, and an event fired from a first-commit mount effect was
+ * gone for good. Queueing directly means the worst case is a late-delivered
+ * event, never a lost one.
+ */
 export function trackEvent<E extends GAEventName>(
   name: E,
   params: GAEventMap[E]
 ): void {
   const payload = { currency: CURRENCY, ...params };
-  const gtag =
-    typeof window === "undefined"
-      ? undefined
-      : (window as unknown as { gtag?: GtagFn }).gtag;
 
-  if (gtag) {
-    gtag("event", name, payload);
-  } else if (process.env.NODE_ENV !== "production") {
+  if (typeof window === "undefined") return;
+  const w = window as unknown as GAWindow;
+
+  if (w.gtag) {
+    w.gtag("event", name, payload);
+    return;
+  }
+
+  if (w.dataLayer) {
+    (queueCommand as unknown as GtagFn)("event", name, payload);
+    return;
+  }
+
+  // GA is not on this build at all (dev/localhost) — log so wiring stays
+  // verifiable locally.
+  if (process.env.NODE_ENV !== "production") {
     console.debug("[ga4]", name, payload);
   }
 }


### PR DESCRIPTION
## What was wrong

`trackEvent` returned silently when `window.gtag` was undefined — and during the first commit that was the normal state, not an edge case.

`<GoogleAnalytics>` is the last child of `<body>`, and `next/script`'s `afterInteractive` tag is injected from an effect. React runs effects child-first, so every mount effect under `{children}` had already run and found no `gtag`. Everything they sent went nowhere:

- `view_item`, `view_item_list`
- and the expensive one — the **`purchase` on `/payment-result`**, which is the only place an online sale is ever counted

Card sales were therefore missing from GA while cash-on-delivery ones, reported later from user interaction, were not. Any comparison between the two payment methods in GA has been wrong for as long as this has been live.

## The fix

Two changes, each needed on its own:

1. The queue stub is now a plain inline `<script>`, so it runs during HTML parse — before any hydration, and before any effect can fire.
2. `trackEvent` pushes straight to `dataLayer` when `gtag` is not there yet. The worst case becomes an event delivered late rather than one lost.

The push sends `arguments` and not an array: `gtag.js` recognises a queued command by that shape and ignores anything else. The test asserts it, because an array looks correct everywhere except in the library meant to replay it.

`gtag.js` itself stays `afterInteractive` — it is ~90 KB, it replays whatever is already in `dataLayer` when it loads, and moving it earlier would cost the perf budget to buy nothing.

## Also here

One chore commit: `.playwright-mcp/` and `.claude/settings.local.json` gitignored (tool scratch and one developer's permissions), `.claude/launch.json` committed because the preview config is worth sharing.

## Verification

- `pnpm test` — 66 pass, including four new tests in `lib/gtag.test.ts`
- `pnpm type-check`, `pnpm lint`, `pnpm build` all clean on top of current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)