### PR TITLE
fix: the blog matches the design it was drawn from

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -81,10 +81,18 @@ export default async function ArticlePage({ params }: PageProps) {
         <div className="container-main flex flex-col gap-6 lg:gap-8">
           {/* Both ends of one line rather than a "Блог / 5 хв." breadcrumb: the
               origin sits at the left margin and the cost of reading at the
-              right, which is the same metadata line the cards use. Neither is
-              coral — on a page with no banner the only accent is the text. */}
+              right, which is the same metadata line the cards use.
+
+              One deliberate departure from node 1303:8259, which paints both
+              labels at 48% white: "Блог" keeps the coral. It is the only way
+              back to the listing, and two identical labels at opposite ends of
+              a line give a reader nothing to tell the link from the caption —
+              a distinction the static design never has to make. */}
           <div className="flex items-center justify-between gap-3 text-xs leading-4 font-bold uppercase tracking-[0.03em] text-white/48">
-            <Link href="/blog" className="transition-colors hover:text-white">
+            <Link
+              href="/blog"
+              className="text-coral transition-colors hover:text-coral-dark"
+            >
               Блог
             </Link>
             <span className="whitespace-nowrap">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -79,20 +79,24 @@ export default async function ArticlePage({ params }: PageProps) {
             plain black with its meta row, which is the design's way of saying
             you have arrived at the text rather than at another section. */}
         <div className="container-main flex flex-col gap-6 lg:gap-8">
-          <div className="flex items-center gap-3 font-heading text-xs lg:text-sm font-bold uppercase tracking-wider text-neutral-500">
-            <Link href="/blog" className="text-coral hover:text-coral-dark transition-colors">
+          {/* Both ends of one line rather than a "Блог / 5 хв." breadcrumb: the
+              origin sits at the left margin and the cost of reading at the
+              right, which is the same metadata line the cards use. Neither is
+              coral — on a page with no banner the only accent is the text. */}
+          <div className="flex items-center justify-between gap-3 text-xs leading-4 font-bold uppercase tracking-[0.03em] text-white/48">
+            <Link href="/blog" className="transition-colors hover:text-white">
               Блог
             </Link>
-            <span aria-hidden>/</span>
-            <span>{article.readingTimeMinutes} хв. читання</span>
+            <span className="whitespace-nowrap">
+              {article.readingTimeMinutes} хв. читання
+            </span>
           </div>
 
-          {/* The banner's headline scale, kept even though there is no banner:
-              the article opens where /blog's red panel would be, and a title
-              a size smaller there reads as a subheading of nothing. */}
-          <h1 className="font-heading text-[32px] lg:text-[48px] leading-tight font-bold text-white">
-            {article.title}
-          </h1>
+          {/* H2's scale, not H1's, even though this is the page's h1: the
+              article opens where /blog's red panel would be, and the design
+              sets the title at 40/52 there. font-bold because preflight resets
+              heading weight and Druk ships only a 700 face. */}
+          <h1 className="text-h2 font-bold text-white">{article.title}</h1>
 
           <div className="relative aspect-[16/9] w-full overflow-hidden rounded-[24px] lg:rounded-section bg-surface">
             <Image

--- a/components/ui/article-card.tsx
+++ b/components/ui/article-card.tsx
@@ -21,9 +21,12 @@ interface ArticleCardProps {
 export function ArticleCard({ article, aboveTheFold = false }: ArticleCardProps) {
   return (
     <article className="group">
-      <Link href={`/blog/${article.slug}`} className="block">
-        <div className="bg-surface rounded-[24px] lg:rounded-[32px] overflow-hidden h-full flex flex-col">
-          <div className="relative aspect-[16/10] overflow-hidden">
+      <Link href={`/blog/${article.slug}`} className="block h-full">
+        {/* The cover is inset by the card's own padding rather than bleeding to
+            its edges — the one structural difference from ProductCard, which
+            this card was otherwise cloned from. */}
+        <div className="bg-surface rounded-[32px] p-5 h-full flex flex-col gap-5">
+          <div className="relative h-[220px] w-full rounded-[24px] overflow-hidden shrink-0">
             <Image
               src={article.cover.url}
               alt={article.cover.alt}
@@ -39,27 +42,36 @@ export function ArticleCard({ article, aboveTheFold = false }: ArticleCardProps)
             />
           </div>
 
-          <div className="px-5 lg:px-6 pt-4 pb-5 lg:pt-5 lg:pb-6 flex flex-col gap-3">
-            <div className="flex items-center gap-3">
-              <span className="inline-flex items-center rounded-full bg-coral px-3 py-1 font-heading text-xs font-bold uppercase tracking-wider text-white">
-                {article.category}
-              </span>
-              <span className="text-sm text-neutral-400">
+          <div className="flex flex-col gap-4">
+            {/* Category and reading time sit at opposite ends of the row, which
+                is what makes the reading time read as metadata about the card
+                rather than as a second label next to the first. */}
+            <div className="flex items-center justify-between gap-3 text-xs leading-4 uppercase tracking-[0.03em]">
+              <span className="font-bold text-coral">{article.category}</span>
+              <span className="font-semibold text-white/48 whitespace-nowrap">
                 {article.readingTimeMinutes} хв. читання
               </span>
             </div>
 
-            {/* h2 for the document outline — the h1 is the page's banner. The
-                font is set back to the body face on purpose: the base layer
-                gives every h2 the Druk heading face, and a card title in Druk
-                is a different card language from the product grid's. */}
-            <h2 className="font-sans text-lg lg:text-xl leading-tight tracking-[0.01em] font-medium text-white">
-              {article.title}
-            </h2>
+            <div className="flex flex-col gap-2">
+              {/* h2 for the document outline — the h1 is the page's banner. The
+                  base layer already gives it the Druk face, which is what the
+                  design asks for; only the size is brought down from text-h2 to
+                  the 16/24 the card uses. */}
+              {/* font-bold explicitly: preflight resets heading weight to
+                  inherit, and Druk ships only a 700 face — so without this the
+                  browser is asked for a 400 that does not exist. */}
+              <h2 className="text-body-2 font-bold tracking-[0.03em] text-white line-clamp-2">
+                {article.title}
+              </h2>
 
-            <p className="text-sm lg:text-base leading-snug text-neutral-400 line-clamp-3">
-              {article.excerpt}
-            </p>
+              {/* Clamped so every card in a row ends at the same place: the
+                  cover is a fixed height and the title is capped at two lines,
+                  so this is the only part left that could stagger them. */}
+              <p className="font-sans text-body-2 font-medium tracking-[0.01em] text-white/48 line-clamp-3">
+                {article.excerpt}
+              </p>
+            </div>
           </div>
         </div>
       </Link>


### PR DESCRIPTION
Brings the blog's two surfaces in line with Figma — the listing card ([1303:8215](https://www.figma.com/design/MsYv7oeA9QSB5PSl9f6RJm/Invitus-Digital?node-id=1303-8215)) and the article page's meta header ([1303:8259](https://www.figma.com/design/MsYv7oeA9QSB5PSl9f6RJm/Invitus-Digital?node-id=1303-8259)).

Based on `main`. Two files, presentation only — the shared Strapi retry loop that briefly rode along here now lands separately in #74.

## 1. `ArticleCard` — the cover is inset, not edge-to-edge

The card was cloned from `ProductCard` and kept its layout. That is the wrong one: a product photo bleeds to the card's edges, an article cover is **inset by the card's own padding** and carries its own radius. That single structural difference accounts for most of the mismatch.

| | before | after (design) |
|---|---|---|
| cover | edge-to-edge, `aspect-[16/10]`, card radius 24/32 | inset in 20px padding, fixed `220px`, radius 24 inside a 32 card |
| category | coral pill, white text, Druk | coral **text** `#E74223`, Golos 700, 12/16, uppercase |
| reading time | next to the category, `text-sm` neutral-400 | far end of the row (`justify-between`), same uppercase 12/16 label at 48% white |
| title | body face, 18/20px | **Druk** 16/24, 3% tracking, clamped to 2 lines |
| excerpt | `text-sm`/`text-base`, neutral-400 | 16/24, 1% tracking, 48% white |

Clamping the title to two lines matters once the cover is a fixed height: it leaves the excerpt as the only variable, so cards in a row end level.

## 2. Article page header — one metadata line, not a breadcrumb

The row was built as a breadcrumb: coral "Блог", a slash, then the reading time, all bunched at the left margin. The design has no slash and no bunching — two labels at opposite ends of the container, Golos Bold 12/16, the same metadata line the card now uses. The title takes `text-h2` (40/52 desktop — what `Desktop/H2` resolves to) instead of a hand-picked `32px`/`48px`.

**One deliberate departure.** The design paints *both* ends at 48% white. Shipped that way first, and on the real page it reads wrong: "Блог" is the only way back to the listing, and two identical labels at opposite ends of a line give the reader nothing to tell the link from the caption — a question a static frame never has to answer. So the reading time keeps 48% white and "Блог" keeps its coral. Owner's call after the difference was raised; the reason is recorded in the markup so it doesn't get "fixed" back.

**`font-bold` on both titles** is not decoration: preflight resets heading weight to `inherit`, and Druk ships a single 700 face — without it the browser is asked for a 400 that does not exist. Only visible in the computed styles; both titles looked bold either way.

## Verification

Measured against the Figma values rather than eyeballed.

**Card** — `440px` tall, exactly the design's `20 + 220 + 20 + 160 + 20`; `rgb(20,20,20)` = `#141414`, radius 32, padding 20, gap 20; cover radius 24; category `#E74223` 700 12/16 at `0.36px`; title `drukWide` 700 16/24 at `0.48px`; reading time and excerpt at 48% white.

**Header** — 40/52 weight 700 letter-spacing 0 at desktop, 28/36 at mobile, 32px gap, row spanning the full 1344px container with "Блог" on the left edge and the reading time on the right.

Checked at 1440/1280 and 375, no page console errors. Re-run on the `main` base: `pnpm type-check`, `pnpm lint`, `pnpm test` (121 pass) and `pnpm build` — all green, `/blog` and `/blog/[slug]` prerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)