### PR TITLE
refactor: three Strapi loaders, one retry loop (re-land #72)

### DIFF
--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -34,7 +34,11 @@
 // literally. tsconfig has `allowImportingTsExtensions` for exactly this — same
 // as lib/promo.ts.
 import { readingTimeMinutes, type BlocksNode } from "./article-body.ts";
-import { getStrapiMedia, getStrapiURL } from "./strapi.ts";
+import { getStrapiMedia } from "./strapi.ts";
+import {
+  requiredStrapiAuthHeaders,
+  strapiGetWithRetries,
+} from "./strapi-fetch.ts";
 import type { Article, ArticleSummary } from "../types/index.ts";
 
 /** Cache tag busted by the Strapi webhook at app/api/revalidate. */
@@ -183,49 +187,24 @@ export class ArticlesUnavailableError extends Error {
   }
 }
 
+/**
+ * The shared Strapi GET, with this module's budget bound to it. Both reads —
+ * the list and one slug — go through here, so a page cannot end up on a budget
+ * the note above ATTEMPT_TIMEOUTS_MS does not describe.
+ */
 async function getWithRetries<T>(query: string): Promise<T> {
-  const token = process.env.STRAPI_API_TOKEN;
-  if (!token) {
-    // Not retryable and not a Strapi problem: Strapi answers 403 anonymously
-    // for articles, so without the token the blog cannot be read at all.
-    throw new NonRetryableError("STRAPI_API_TOKEN is not set (server-only)");
-  }
-
-  const url = getStrapiURL(query);
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= ATTEMPT_TIMEOUTS_MS.length; attempt++) {
-    try {
-      const response = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(ATTEMPT_TIMEOUTS_MS[attempt - 1]),
-        next: { revalidate: REVALIDATE_S, tags: [STRAPI_ARTICLES_TAG] },
-      });
-
-      if (response.status >= 400 && response.status < 500) {
-        throw new NonRetryableError(`Strapi responded ${response.status}`);
-      }
-      if (!response.ok) throw new Error(`Strapi responded ${response.status}`);
-
-      return (await response.json()) as T;
-    } catch (error) {
-      if (error instanceof NonRetryableError) throw error;
-      lastError = error;
-      if (attempt < ATTEMPT_TIMEOUTS_MS.length) {
-        const reason = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `[articles] Strapi attempt ${attempt}/${ATTEMPT_TIMEOUTS_MS.length} ` +
-            `failed (${reason}), retrying`
-        );
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-      }
-    }
-  }
-
-  throw lastError;
+  return strapiGetWithRetries<T>({
+    query,
+    tag: STRAPI_ARTICLES_TAG,
+    timeouts: ATTEMPT_TIMEOUTS_MS,
+    retryDelay: RETRY_DELAY_MS,
+    revalidate: REVALIDATE_S,
+    logPrefix: "[articles]",
+    // Strapi answers 403 anonymously for articles, so without the token the
+    // blog cannot be read at all — a failure no retry can fix.
+    headers: requiredStrapiAuthHeaders(),
+  });
 }
-
-class NonRetryableError extends Error {}
 
 // ── mapping ──────────────────────────────────────────────────────────────────
 

--- a/lib/product-extras.ts
+++ b/lib/product-extras.ts
@@ -34,7 +34,12 @@
 // deliberately long: the fewer times we touch Strapi, the fewer chances a blip
 // there has to become a visible bug here.
 
-import { getStrapiURL, getStrapiMedia } from "./strapi";
+import { getStrapiMedia } from "./strapi";
+import {
+  strapiAuthHeaders,
+  strapiGetWithRetries,
+  StrapiNotFoundError,
+} from "./strapi-fetch";
 import { slugify } from "./slugify";
 import type {
   StrapiHomepage,
@@ -77,7 +82,7 @@ export const STRAPI_EXTRAS_TAG = "strapi-extras";
 // the wake-up, so the retry is usually the fast case.
 const ATTEMPT_TIMEOUT_MS = 12_000;
 const MAX_ATTEMPTS = 3;
-const RETRY_DELAY_MS = 1_000;
+const ATTEMPT_TIMEOUTS_MS = Array<number>(MAX_ATTEMPTS).fill(ATTEMPT_TIMEOUT_MS);
 
 // Safety net for a missed webhook, not the freshness mechanism. See the note
 // at the top of this file.
@@ -225,10 +230,13 @@ const HOMEPAGE_QUERY =
  * the fallback render.
  */
 async function fetchWithRetries(): Promise<StrapiResponse<StrapiProduct[]>> {
-  return getWithRetries<StrapiResponse<StrapiProduct[]>>(
-    PRODUCTS_QUERY,
-    "extras"
-  );
+  return strapiGetWithRetries<StrapiResponse<StrapiProduct[]>>({
+    query: PRODUCTS_QUERY,
+    tag: STRAPI_EXTRAS_TAG,
+    timeouts: ATTEMPT_TIMEOUTS_MS,
+    revalidate: REVALIDATE_S,
+    logPrefix: "[extras]",
+  });
 }
 
 /**
@@ -248,24 +256,29 @@ async function fetchHomepage(): Promise<HomepageLists> {
   if (Date.now() < homepageSkipUntil) return lastGood?.homepage ?? EMPTY_HOMEPAGE;
 
   try {
-    const json = await getWithRetries<StrapiResponse<StrapiHomepage | null>>(
-      HOMEPAGE_QUERY,
-      "homepage",
+    const json = await strapiGetWithRetries<
+      StrapiResponse<StrapiHomepage | null>
+    >({
+      query: HOMEPAGE_QUERY,
+      tag: STRAPI_EXTRAS_TAG,
+      timeouts: ATTEMPT_TIMEOUTS_MS,
+      revalidate: REVALIDATE_S,
+      logPrefix: "[homepage]",
       // Products are readable anonymously; the `Homepage` single type is not —
       // its find permission is granted to the API token, and an unauthenticated
       // read gets a 403 that would leave the homepage on the `featured`
       // fallback forever. Only this query carries the token: putting the
       // products query behind a second auth surface would add a way for
       // something that works today to start failing, and buy nothing.
-      strapiAuthHeaders()
-    );
+      headers: strapiAuthHeaders(),
+    });
     return {
       showcase: toProductRefs(json.data?.showcase) ?? [],
       shopCta: toProductRefs(json.data?.shopCta) ?? [],
     };
   } catch (error) {
     homepageSkipUntil = Date.now() + FAILURE_BACKOFF_MS;
-    if (!(error instanceof NotFoundError)) {
+    if (!(error instanceof StrapiNotFoundError)) {
       const reason = error instanceof Error ? error.message : String(error);
       console.warn(
         `Strapi homepage fetch failed (${reason}), ` +
@@ -275,58 +288,6 @@ async function fetchHomepage(): Promise<HomepageLists> {
     return lastGood?.homepage ?? EMPTY_HOMEPAGE;
   }
 }
-
-/** Server-only module, so the token never reaches the client bundle. */
-function strapiAuthHeaders(): Record<string, string> {
-  const token = process.env.STRAPI_API_TOKEN;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-async function getWithRetries<T>(
-  query: string,
-  label: string,
-  headers: Record<string, string> = {}
-): Promise<T> {
-  const url = getStrapiURL(query);
-
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    try {
-      const response = await fetch(url, {
-        headers,
-        signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
-        next: { revalidate: REVALIDATE_S, tags: [STRAPI_EXTRAS_TAG] },
-      });
-
-      if (response.status === 404) {
-        throw new NotFoundError(`Strapi responded 404`);
-      }
-      if (response.status >= 400 && response.status < 500) {
-        throw new NonRetryableError(`Strapi responded ${response.status}`);
-      }
-      if (!response.ok) throw new Error(`Strapi responded ${response.status}`);
-
-      return (await response.json()) as T;
-    } catch (error) {
-      if (error instanceof NonRetryableError) throw error;
-      lastError = error;
-      if (attempt < MAX_ATTEMPTS) {
-        const reason = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `Strapi ${label} attempt ${attempt}/${MAX_ATTEMPTS} failed (${reason}), retrying`
-        );
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-      }
-    }
-  }
-
-  throw lastError;
-}
-
-class NonRetryableError extends Error {}
-/** A 4xx that carries meaning: the single type has no saved entry yet. */
-class NotFoundError extends NonRetryableError {}
 
 /**
  * Strapi relation entries → unresolved pointers. Returns undefined for an empty

--- a/lib/promo-codes.ts
+++ b/lib/promo-codes.ts
@@ -23,7 +23,10 @@
 // answers 403 anonymously, and it should stay that way: a public collection of
 // promo codes is a public list of discounts.
 
-import { getStrapiURL } from "./strapi";
+import {
+  requiredStrapiAuthHeaders,
+  strapiGetWithRetries,
+} from "./strapi-fetch";
 import {
   evaluatePromoCode,
   indexPromoCodes,
@@ -48,7 +51,6 @@ export const STRAPI_PROMO_TAG = "strapi-promo-codes";
 // lands quickly or is not going to land at all. Worst case ~29s and the ordinary
 // cold case succeeds outright, against 38s of guaranteed failure before.
 const ATTEMPT_TIMEOUTS_MS = [20_000, 8_000];
-const RETRY_DELAY_MS = 1_000;
 const REVALIDATE_S = 86_400;
 const FAILURE_BACKOFF_MS = 60_000;
 
@@ -113,7 +115,16 @@ async function fetchPromoCodes(): Promise<Map<string, PromoCode> | null> {
   try {
     // Sorted oldest-first by the query, which is what makes indexPromoCodes'
     // duplicate rule ("the first wins") mean the same thing on every server.
-    const json = await getWithRetries<{ data: RawPromoCode[] }>();
+    const json = await strapiGetWithRetries<{ data: RawPromoCode[] }>({
+      query: QUERY,
+      tag: STRAPI_PROMO_TAG,
+      timeouts: ATTEMPT_TIMEOUTS_MS,
+      revalidate: REVALIDATE_S,
+      logPrefix: "[promo]",
+      // Strapi answers 403 anonymously, so without the token every code on the
+      // site is refused — not a Strapi problem and not worth retrying.
+      headers: requiredStrapiAuthHeaders(),
+    });
 
     lastGood = indexPromoCodes(json.data ?? []);
     return lastGood;
@@ -128,47 +139,3 @@ async function fetchPromoCodes(): Promise<Map<string, PromoCode> | null> {
     return lastGood;
   }
 }
-
-async function getWithRetries<T>(): Promise<T> {
-  const token = process.env.STRAPI_API_TOKEN;
-  if (!token) {
-    // Not retryable and not a Strapi problem: Strapi answers 403 anonymously,
-    // so without the token every code on the site is refused.
-    throw new NonRetryableError("STRAPI_API_TOKEN is not set (server-only)");
-  }
-
-  const url = getStrapiURL(QUERY);
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= ATTEMPT_TIMEOUTS_MS.length; attempt++) {
-    try {
-      const response = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(ATTEMPT_TIMEOUTS_MS[attempt - 1]),
-        next: { revalidate: REVALIDATE_S, tags: [STRAPI_PROMO_TAG] },
-      });
-
-      if (response.status >= 400 && response.status < 500) {
-        throw new NonRetryableError(`Strapi responded ${response.status}`);
-      }
-      if (!response.ok) throw new Error(`Strapi responded ${response.status}`);
-
-      return (await response.json()) as T;
-    } catch (error) {
-      if (error instanceof NonRetryableError) throw error;
-      lastError = error;
-      if (attempt < ATTEMPT_TIMEOUTS_MS.length) {
-        const reason = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `[promo] Strapi attempt ${attempt}/${ATTEMPT_TIMEOUTS_MS.length} ` +
-            `failed (${reason}), retrying`
-        );
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-      }
-    }
-  }
-
-  throw lastError;
-}
-
-class NonRetryableError extends Error {}

--- a/lib/strapi-fetch.ts
+++ b/lib/strapi-fetch.ts
@@ -1,0 +1,138 @@
+// One GET against Strapi, retried on anything transient. Server-only.
+//
+// Three loaders read Strapi through this — lib/product-extras.ts,
+// lib/promo-codes.ts and lib/articles.ts — and they had grown three copies of
+// the same loop. The copies are the hazard: the 4xx rule and the cold-start
+// budget are the sort of thing that gets fixed in one file and left wrong in
+// the other two.
+//
+// What is shared is only the *transport*: how many attempts, how long each
+// waits, which statuses are worth another try, and the cache entry the answer
+// lands in. Everything a caller does with a failure stays with the caller,
+// because the three answers are deliberately different and must stay that way —
+// extras degrade to fallbacks, a promo code is refused with an explanation, the
+// blog refuses to render at all. See the note at the top of each file.
+//
+// The budgets are passed in for the same reason — each was arrived at from what
+// its caller loses by giving up, and they are not interchangeable. See the note
+// above the timeouts in each file before touching one.
+
+import { getStrapiURL } from "./strapi.ts";
+
+/**
+ * A failure no retry can fix — a bad token, a malformed query. Burning the rest
+ * of the budget on it only delays the caller's fallback.
+ */
+export class StrapiNonRetryableError extends Error {}
+
+/** A 4xx that carries meaning: a single type nobody has saved yet. */
+export class StrapiNotFoundError extends StrapiNonRetryableError {}
+
+// Long enough that a wedged connection isn't retried instantly, short enough to
+// be invisible next to the attempt timeouts it sits between. A caller retrying
+// against an instance it is trying to *wake* wants longer — see `retryDelay`.
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+
+export interface StrapiGetOptions {
+  /** Path and query string, passed to getStrapiURL. */
+  query: string;
+  /** Cache tag, busted by the Strapi webhook at app/api/revalidate. */
+  tag: string;
+  /** Per-attempt timeouts, in order. Its length is the attempt count. */
+  timeouts: readonly number[];
+  /** Cache window in seconds — a safety net for a missed webhook, not the
+   *  freshness mechanism. */
+  revalidate: number;
+  /** Bracketed label leading every log line, e.g. "[promo]". */
+  logPrefix: string;
+  /** Extra request headers — authorization, typically. See strapiAuthHeaders. */
+  headers?: Record<string, string>;
+  /**
+   * Gap between attempts. Defaults to 1s, which is the "don't hammer a wedged
+   * connection" case. Pass more when the retry is aimed at an instance the
+   * previous attempt started waking and the gap is what gives it time to
+   * finish — lib/articles.ts spends 2.5s for exactly that.
+   */
+  retryDelay?: number;
+}
+
+/**
+ * Fetch and parse one Strapi endpoint, retrying transient failures.
+ *
+ * Throws `StrapiNotFoundError` on 404, `StrapiNonRetryableError` on any other
+ * 4xx (immediately, without spending the remaining attempts), and whatever the
+ * final attempt failed with once the budget is exhausted.
+ */
+export async function strapiGetWithRetries<T>({
+  query,
+  tag,
+  timeouts,
+  revalidate,
+  logPrefix,
+  headers = {},
+  retryDelay = DEFAULT_RETRY_DELAY_MS,
+}: StrapiGetOptions): Promise<T> {
+  const url = getStrapiURL(query);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= timeouts.length; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(timeouts[attempt - 1]),
+        next: { revalidate, tags: [tag] },
+      });
+
+      if (response.status === 404) {
+        throw new StrapiNotFoundError("Strapi responded 404");
+      }
+      if (response.status >= 400 && response.status < 500) {
+        throw new StrapiNonRetryableError(`Strapi responded ${response.status}`);
+      }
+      if (!response.ok) throw new Error(`Strapi responded ${response.status}`);
+
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof StrapiNonRetryableError) throw error;
+      lastError = error;
+      if (attempt < timeouts.length) {
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `${logPrefix} Strapi attempt ${attempt}/${timeouts.length} ` +
+            `failed (${reason}), retrying`
+        );
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * The authorization header when a token is configured, and nothing when it
+ * isn't. For collections Strapi serves anonymously, where the token is an
+ * optional upgrade rather than a requirement.
+ */
+export function strapiAuthHeaders(): Record<string, string> {
+  const token = process.env.STRAPI_API_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * The authorization header, or a non-retryable failure.
+ *
+ * For the collections Strapi answers 403 on anonymously — promo codes and
+ * articles. A missing token is not a Strapi problem and no number of attempts
+ * will produce one, so it fails the way a bad token does: at once, with a
+ * message saying what is actually wrong.
+ */
+export function requiredStrapiAuthHeaders(): Record<string, string> {
+  const token = process.env.STRAPI_API_TOKEN;
+  if (!token) {
+    throw new StrapiNonRetryableError(
+      "STRAPI_API_TOKEN is not set (server-only)"
+    );
+  }
+  return { Authorization: `Bearer ${token}` };
+}


### PR DESCRIPTION
Lands #72 on `main`, where it never arrived.

#71 (`feat/blog` → `main`) merged at 20:06:18; #72 (`refactor/strapi-retry` → **`feat/blog`**) merged at 20:06:31 — 13 seconds later, into a branch that had already been merged. GitHub shows #72 as "Merged", so the gap is invisible from the PR list, but `main` has no `lib/strapi-fetch.ts` and `lib/articles.ts` still carries its own copy of the retry loop.

The diff is exactly the four files #72 reviewed, unchanged — same commit (`a6cb5f4`), no rebase, no edits.

## What it does

`lib/strapi-fetch.ts` owns the transport shared by the three Strapi loaders: attempt count, per-attempt timeout, the `404` / other-4xx non-retryable split, the gap between attempts, and the cache entry the answer lands in.

What deliberately stays with each caller is every reason they differ — their own `lastGood`, back-off, single-flight guard, budget, and answer to an unreachable Strapi:

| loader | budget | on failure |
|---|---|---|
| `product-extras` | 3 × 12s | `lastGood` → fallbacks |
| `promo-codes` | `[20s, 8s]` | `lastGood` → refuse the code with an explanation |
| `articles` | `[20s, 15s, 15s]`, 2.5s gap | `lastGood` → `ArticlesUnavailableError`, never `[]` |

Verified again on this base: `pnpm type-check`, `pnpm lint`, `pnpm test` (121 pass) and `pnpm build` — green, with `/blog`, `/blog/[slug]` and all 31 product pages prerendering against the live Strapi.

After this merges, `feat/blog` is fully contained in `main` and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)