### PR TITLE
Склад із KeyCRM у розмірах + сторінка товару переживає втрату WebGL-контексту

### DIFF
--- a/components/models/model-loader.tsx
+++ b/components/models/model-loader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useCallback, useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ArnoldLoader } from "@/components/ui/arnold-loader";
 import { useIsHydrated } from "@/hooks/use-is-hydrated";
@@ -41,7 +41,21 @@ function CameraController() {
 interface ModelLoaderProps {
   modelUrl?: string;
   fallbackModelUrl?: string;
+  /**
+   * Called when the canvas has lost its WebGL context more times than it is
+   * worth retrying. The product page uses it to fall back to the photo — a
+   * still picture of the belt beats an empty box where the belt should be.
+   */
+  onGaveUp?: () => void;
 }
+
+/**
+ * How many times a lost context is worth rebuilding. Two, because the loss we
+ * actually see comes from a mount/unmount race and clears on the retry; a
+ * context that dies twice in a row is a machine that cannot keep this canvas,
+ * and retrying forever would just spin.
+ */
+const MAX_CONTEXT_RECOVERIES = 2;
 
 // Loading overlay with progress
 function LoadingOverlay({ modelUrl }: { modelUrl?: string }) {
@@ -103,10 +117,38 @@ function LoadingOverlay({ modelUrl }: { modelUrl?: string }) {
 }
 
 // Main component with Canvas and loading
-export function ModelLoader({ modelUrl, fallbackModelUrl }: ModelLoaderProps) {
+export function ModelLoader({
+  modelUrl,
+  fallbackModelUrl,
+  onGaveUp,
+}: ModelLoaderProps) {
   // WebGL has no server-side equivalent, so the canvas cannot be part of the
   // server render — show the loader until hydration has happened.
   const isClient = useIsHydrated();
+
+  // Bumped to rebuild the canvas after a lost context. It is a `key`, so React
+  // throws the old <canvas> away and mounts a new one: an element whose context
+  // has been lost can never be given a working one again, so reusing it would
+  // rebuild the renderer around a corpse.
+  const [generation, setGeneration] = useState(0);
+
+  const handleContextLost = useCallback(
+    (event: Event) => {
+      // Without preventDefault the browser will not even attempt to restore,
+      // and — more to the point here — three.js stops rendering either way, so
+      // the canvas stays blank until something rebuilds it. That something is
+      // the generation bump below.
+      event.preventDefault();
+      setGeneration((n) => {
+        if (n >= MAX_CONTEXT_RECOVERIES) {
+          onGaveUp?.();
+          return n;
+        }
+        return n + 1;
+      });
+    },
+    [onGaveUp]
+  );
 
   if (!isClient) {
     return (
@@ -120,7 +162,15 @@ export function ModelLoader({ modelUrl, fallbackModelUrl }: ModelLoaderProps) {
 
   return (
     <div className="absolute inset-0 z-10 cursor-grab active:cursor-grabbing">
-      <Canvas camera={{ position: [0, 0.5, 3], fov: 45 }}>
+      <Canvas
+        key={generation}
+        camera={{ position: [0, 0.5, 3], fov: 45 }}
+        onCreated={({ gl }) => {
+          gl.domElement.addEventListener("webglcontextlost", handleContextLost, {
+            once: true,
+          });
+        }}
+      >
         <CameraController />
         <ambientLight intensity={0.1} />
         <directionalLight position={[5, 5, 5]} intensity={1} castShadow />

--- a/components/product/product-page-content.tsx
+++ b/components/product/product-page-content.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useIsHydrated } from "@/hooks/use-is-hydrated";
+import { DESKTOP_QUERY, useMediaQuery } from "@/hooks/use-media-query";
 import { motion } from "framer-motion";
 import { Plus } from "lucide-react";
 import { gaItem, trackEvent } from "@/lib/gtag";
@@ -22,9 +24,19 @@ const PRODUCT_BG_FALLBACK = "/assets/img/product_bg.png";
 export function ProductPageContent({ product }: ProductPageContentProps) {
   // The whole size is held, not just its value: the cart needs the label to
   // show what the product page showed, and the order needs the KeyCRM value.
+  //
+  // The pre-selection skips whatever KeyCRM has none of: landing on a sold-out
+  // first size would put a size nobody can buy under the cursor and leave the
+  // button dead on arrival, which reads as the page being broken.
   const [selectedSize, setSelectedSize] = useState<ProductSize | null>(
-    product.sizes?.[0] ?? null
+    product.sizes?.find((s) => s.inStock) ?? null
   );
+  // Sold out only when the product has sizes and none of them is left; a
+  // product with no offers at all is not a stock question and stays buyable.
+  const soldOut = Boolean(product.sizes?.length) && !selectedSize;
+  // Set when the canvas has lost its WebGL context past recovering. The page
+  // then shows the product photo instead of an empty box.
+  const [modelUnavailable, setModelUnavailable] = useState(false);
   const addItem = useAddToCart();
   const openCart = useOpenCart();
 
@@ -50,9 +62,21 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
   //
   // Without a model we now show the product's own photo instead: a Strapi
   // outage degrades to "real photo, no 3D" rather than "wrong belt".
-  const show3dModel = Boolean(product.model3dUrl);
+  const show3dModel = Boolean(product.model3dUrl) && !modelUnavailable;
+
+  // Both layouts are in the tree at once — Tailwind hides one, it does not skip
+  // it — so an unguarded viewer mounts twice and the hidden copy quietly holds a
+  // second WebGL context and a second copy of the model. Only the layout that is
+  // actually on screen gets one, and neither gets one before hydration: mounting
+  // the wrong one for a frame and tearing it straight down is what makes r3f
+  // fire its deferred `forceContextLoss()` into the surviving canvas.
+  const isDesktop = useMediaQuery(DESKTOP_QUERY);
+  const isHydrated = useIsHydrated();
+  const mobile3d = show3dModel && isHydrated && !isDesktop;
+  const desktop3d = show3dModel && isHydrated && isDesktop;
 
   const handleAddToCart = () => {
+    if (soldOut) return;
     addItem(product, selectedSize?.value, selectedSize?.label);
     openCart();
   };
@@ -78,9 +102,10 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
           {/* Hero media: 3D model (belts) or product photo */}
           <div className="py-[60px] sm:py-0 rounded-t-[28px] overflow-hidden">
             <div className="relative h-[200px] sm:h-[340px] md:h-[420px]">
-              {show3dModel ? (
+              {mobile3d ? (
                 <ModelViewer
                   modelUrl={product.model3dUrl}
+                  onGaveUp={() => setModelUnavailable(true)}
                 />
               ) : (
                 <ProductMedia
@@ -130,9 +155,10 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
         <CTAButton
           width="fill"
           onClick={handleAddToCart}
-          icon={<Plus className="w-5 h-5" />}
+          disabled={soldOut}
+          icon={soldOut ? null : <Plus className="w-5 h-5" />}
         >
-          Додати в кошик
+          {soldOut ? "Немає в наявності" : "Додати в кошик"}
         </CTAButton>
       </div>
 
@@ -152,9 +178,10 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
         </div>
 
         {/* Hero media: 3D model (belts) or product photo */}
-        {show3dModel ? (
+        {desktop3d ? (
           <ModelViewer
             modelUrl={product.model3dUrl}
+            onGaveUp={() => setModelUnavailable(true)}
           />
         ) : (
           <div className="absolute inset-0 z-10 flex items-center justify-center pb-40">
@@ -207,8 +234,13 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
                     howToMeasure={product.howToMeasure}
                     careInstructions={product.careInstructions}
                   />
-                  <CTAButton width="fill" onClick={handleAddToCart}>
-                    Додати в кошик
+                  <CTAButton
+                    width="fill"
+                    onClick={handleAddToCart}
+                    disabled={soldOut}
+                    icon={soldOut ? null : undefined}
+                  >
+                    {soldOut ? "Немає в наявності" : "Додати в кошик"}
                   </CTAButton>
                 </motion.div>
               </div>

--- a/components/product/size-selector.tsx
+++ b/components/product/size-selector.tsx
@@ -10,6 +10,11 @@ interface SizeSelectorProps {
   onSelect: (size: ProductSize) => void;
 }
 
+/**
+ * The sizes a product is made in. A size KeyCRM has none of stays on screen —
+ * struck through and unclickable — because a missing chip reads as "we do not
+ * make that size" rather than "it is out this week".
+ */
 export function SizeSelector({
   sizes,
   selectedSize,
@@ -24,6 +29,8 @@ export function SizeSelector({
           key={size.value}
           onClick={() => onSelect(size)}
           isActive={selectedSize === size.value}
+          disabled={!size.inStock}
+          title={size.inStock ? undefined : "Немає в наявності"}
         >
           {size.label}
         </ChipButton>

--- a/components/ui/chip-button.tsx
+++ b/components/ui/chip-button.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils";
 interface ChipButtonProps {
   children: React.ReactNode;
   isActive?: boolean;
+  disabled?: boolean;
+  title?: string;
   onClick?: () => void;
   className?: string;
 }
@@ -12,17 +14,26 @@ interface ChipButtonProps {
 export function ChipButton({
   children,
   isActive = false,
+  disabled = false,
+  title,
   onClick,
   className,
 }: ChipButtonProps) {
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
+      title={title}
       className={cn(
         "px-6 py-4 rounded-[20px] cursor-pointer font-heading text-base leading-6 font-bold tracking-[0.1em] text-center transition-colors whitespace-nowrap",
         isActive
           ? "bg-white text-black"
           : "bg-[#0000007A] text-white",
+        // Struck through as well as dimmed: opacity alone reads as a styling
+        // accident on a dark card, and the line says "gone" without a label
+        // that would not fit inside a chip.
+        disabled &&
+          "cursor-not-allowed opacity-40 line-through bg-[#0000007A] text-white",
         className
       )}
     >

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * Whether a CSS media query currently matches. `false` on the server and
+ * through hydration, then the real answer.
+ *
+ * Exists so a component can be mounted for one breakpoint only. Tailwind's
+ * `lg:hidden` / `hidden lg:block` pair hides markup, it does not skip it — both
+ * branches mount, and for anything that owns a resource (a WebGL canvas, a
+ * video element) that means paying for it twice and animating one copy nobody
+ * can see.
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const list = window.matchMedia(query);
+      list.addEventListener("change", onChange);
+      return () => list.removeEventListener("change", onChange);
+    },
+    [query]
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false
+  );
+}
+
+/** The `lg` breakpoint, where the product page swaps to its desktop layout. */
+export const DESKTOP_QUERY = "(min-width: 1024px)";

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -19,6 +19,7 @@
 import { fetchKeyCrm, fetchKeyCrmAll } from "./keycrm";
 import { slugify } from "./slugify";
 import { HIDDEN_CATEGORY_IDS } from "./hidden-categories";
+import { availableStock } from "./offer-stock";
 import { readOfferVariant, VARIANT_PROPERTY_NAMES } from "./variant-property";
 import {
   getStrapiExtras,
@@ -104,16 +105,29 @@ function toProduct(
   // KeyCRM owns which sizes exist; Strapi only supplies nicer wording for them,
   // keyed by the offer SKU. An offer Strapi says nothing about keeps KeyCRM's
   // own value as its label, so a belt added today is merely plainer, not broken.
+  //
+  // Availability is per size value, not per offer: KeyCRM can carry the same
+  // size on more than one offer, and a size is buyable while any of them still
+  // has stock. Reserve counts as gone — quantity alone would keep offering a
+  // belt that is already promised to someone else.
   const sizes: ProductSize[] = [];
-  const seenSizeValues = new Set<string>();
+  const sizeByValue = new Map<string, ProductSize>();
   for (const offer of activeOffers) {
     const value = readOfferVariant(offer)?.value;
-    if (!value || seenSizeValues.has(value)) continue;
-    seenSizeValues.add(value);
-    sizes.push({
+    if (!value) continue;
+    const inStock = availableStock(offer) > 0;
+    const existing = sizeByValue.get(value);
+    if (existing) {
+      existing.inStock ||= inStock;
+      continue;
+    }
+    const size: ProductSize = {
       value,
       label: (offer.sku && extras?.sizeLabelsBySku?.[offer.sku]) || value,
-    });
+      inStock,
+    };
+    sizeByValue.set(value, size);
+    sizes.push(size);
   }
   sizes.sort((a, b) => compareSizes(a.value, b.value));
 
@@ -136,7 +150,7 @@ function toProduct(
         name:
           readOfferVariant(o)?.value ??
           o.properties.map((prop) => prop.value).join(" / "),
-        stock: Math.max(0, o.quantity),
+        stock: availableStock(o),
         sku: o.sku ?? undefined,
         priceModifier: o.price - p.min_price || undefined,
       }))

--- a/lib/offer-stock.ts
+++ b/lib/offer-stock.ts
@@ -1,0 +1,18 @@
+// How much of a KeyCRM offer is actually sellable.
+//
+// Lives on its own for the same reason lib/variant-property.ts does: the size
+// selector and the order pricer must not be able to disagree about what is in
+// stock. A size the page shows as available and a size /order accepts are the
+// same arithmetic, in one place.
+//
+// `quantity` is what sits on the shelf and `in_reserve` is what is already
+// promised to an existing order, so the sellable figure is the difference.
+// KeyCRM does not reserve on our orders today (they arrive with
+// `stock_status: null`), which makes in_reserve normally 0 — subtracting it
+// anyway costs nothing and stops the day reservation is switched on from
+// silently overselling.
+import type { KeyCrmOffer } from "./keycrm-schema";
+
+export function availableStock(offer: KeyCrmOffer): number {
+  return Math.max(0, offer.quantity - (offer.in_reserve ?? 0));
+}

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -12,6 +12,7 @@
 
 import { fetchKeyCrm, postKeyCrm, putKeyCrm } from "./keycrm";
 import type { KeyCrmOffer, KeyCrmProduct } from "./keycrm-schema";
+import { availableStock } from "./offer-stock";
 import { readOfferVariant, VARIANT_PROPERTY_NAMES } from "./variant-property";
 import { orderTotals, type OrderTotals } from "./order-totals";
 import { checkPromoCode } from "./promo-codes";
@@ -180,6 +181,20 @@ async function priceLine(item: OrderDraftItem): Promise<PricedLine> {
     if (!match) {
       throw new OrderPricingError(
         `Розмір «${item.size ?? "—"}» для «${product.name}» недоступний`
+      );
+    }
+
+    // Stock is re-read here, from the uncached offers, because the page that
+    // offered this size was rendered up to a minute ago and the cart may be
+    // days old. The same arithmetic the size selector used (lib/offer-stock.ts)
+    // decides it, so a size cannot be buyable on screen and refused here for
+    // any reason other than the stock genuinely having moved in between.
+    const available = availableStock(match);
+    if (available < item.quantity) {
+      throw new OrderPricingError(
+        available === 0
+          ? `Розмір «${item.size ?? "—"}» для «${product.name}» закінчився`
+          : `Розміру «${item.size ?? "—"}» для «${product.name}» залишилось ${available} шт.`
       );
     }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -35,6 +35,13 @@ export interface ProductSize {
   value: string;
   /** What the customer sees, e.g. "65-80 см". Falls back to `value`. */
   label: string;
+  /**
+   * Whether KeyCRM still has any of this size, reserve already subtracted.
+   * A sold-out size stays in the list — the customer is told the size exists
+   * and is out, not left guessing whether it is made at all — but nothing may
+   * select it, and lib/orders.ts re-checks the same figure before charging.
+   */
+  inStock: boolean;
 }
 
 export interface Product {


### PR DESCRIPTION
Два незалежні виправлення, обидва на сторінці товару.

## Розміри знають про склад

Розміри збиралися з усіх неархівних offers без перевірки залишку — `quantity` читався лише у `variants`, яке UI не рендерить. Оновлення складу в KeyCRM не змінювало на сайті нічого, і замовлення на відсутній розмір проходило.

- `lib/offer-stock.ts` — одне місце, де вирішується наявність (`quantity − in_reserve`), щоб селектор розмірів і прайсер замовлення не могли розійтися. Резерв віднімається наперед: KeyCRM зараз не резервує під наші замовлення, але коли почне — арифметика вже правильна.
- Рахується **на значення розміру**, а не на offer: у футболок той самий розмір лежить на кількох offers.
- Розпроданий розмір лишається на екрані перекресленим і некликабельним — зниклий чіп читається як «ми такого розміру не робимо». Попередньо вибирається перший **доступний** розмір; якщо не лишилось жодного, замість CTA — «Немає в наявності».
- `lib/orders.ts` перевіряє той самий залишок по некешованих offers перед оплатою.

## Втрата WebGL-контексту

Сторінка товару іноді ставала білою плитою з невидимим героєм, у консолі — `THREE.WebGLRenderer: Context Lost.`, при цілому DOM під ним.

Контекст забирав не браузер: перехоплення `WEBGL_lose_context.loseContext()` дало стек `forceContextLoss ← @react-three/fiber` — r3f планує цей виклик по таймеру 500 мс при розмонтуванні канваса, а React StrictMode у dev монтує-розмонтовує-монтує, тож таймер від першого монтування стріляє по живому контексту другого. Підтверджено перемикачем: `reactStrictMode: false` — 0/3 втрат, зі StrictMode — 4/4. З'явилось у 37ba73e, який зробив завантажувач динамічним імпортом.

- `ModelLoader` тепер переживає втрату: `preventDefault()` і `key`-перемонтування **нового** `<canvas>` (елемент, у якого забрали контекст, робочого вже не отримає). Максимум дві спроби, далі — фото товару. Це корисно й у проді, де контекст забирає сам браузер при сплячці, скиданні драйвера чи нестачі пам'яті.
- В'ювер монтується один раз, а не двічі: обидва макети завжди в дереві, тож прихована копія тримала другий WebGL-контекст і другу копію моделі.

## Перевірка

- CDP-харнес у справжньому Chrome: 3/3 завантаження закінчуються одним канвасом і живим контекстом проти 4/4 мертвих до фіксу.
- Дані складу звірені з KeyCRM: Silence (S:3, M:0, L:1) — M перекреслений; Tiger (усі 0) — кнопка вимкнена.
- `pnpm type-check`, `pnpm build`, 121 тест — проходять.

🤖 Generated with [Claude Code](https://claude.com/claude-code)