### PR TITLE
Товар з одним розміром більше не просить обрати розмір

### DIFF
--- a/components/checkout/order-summary.tsx
+++ b/components/checkout/order-summary.tsx
@@ -3,6 +3,7 @@
 import { ProductMedia } from "@/components/ui/product-media";
 import { CTAButton } from "@/components/ui/cta-button";
 import { formatPrice } from "@/lib/format";
+import { cartSizeLabel } from "@/lib/size-display";
 import { useCartItems, useCartTotal } from "@/hooks/use-cart";
 import { useAppliedPromo, usePromoStatus } from "@/hooks/use-promo";
 import { cn } from "@/lib/utils";
@@ -62,9 +63,9 @@ export function OrderSummary({
                   {formatPrice(item.product.price * item.quantity)} ₴
                 </p>
                 <div className="mt-4 space-y-1">
-                  {item.size && (
+                  {cartSizeLabel(item) && (
                     <p className="text-[15px] text-white/78">
-                      Розмір: {item.sizeLabel ?? item.size}
+                      Розмір: {cartSizeLabel(item)}
                     </p>
                   )}
                   {item.quantity > 1 && (
@@ -124,7 +125,8 @@ export function OrderSummary({
 
 /**
  * Compact mobile-top product summary (matches design mockup).
- * Shows only the first item's media + name + price + size.
+ * Shows only the first item's media + name + price + size (when the product is
+ * made in more than one — see lib/size-display.ts).
  */
 export function OrderSummaryMobileTop() {
   const items = useCartItems();
@@ -132,6 +134,8 @@ export function OrderSummaryMobileTop() {
 
   const first = items[0];
   const more = items.length - 1;
+  // Null for a one-size product; the "and N more" tail still has to survive it.
+  const firstSize = cartSizeLabel(first);
 
   return (
     <div className="lg:hidden mt-20 sm:mt-24 pl-6 pr-4 flex gap-4 items-start">
@@ -149,10 +153,16 @@ export function OrderSummaryMobileTop() {
         <p className="mt-2 font-sans font-medium text-base/6 text-white">
           {formatPrice(first.product.price * first.quantity)} ₴
         </p>
-        {first.size && (
+        {(firstSize || more > 0) && (
           <p className="mt-4 font-sans font-medium text-base/6 text-white/50">
-            {first.sizeLabel ?? first.size}
-            {more > 0 ? ` · та ще ${more} ${more === 1 ? "товар" : "товари"}` : ""}
+            {[
+              firstSize,
+              more > 0
+                ? `та ще ${more} ${more === 1 ? "товар" : "товари"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
           </p>
         )}
       </div>

--- a/components/layout/cart-drawer.tsx
+++ b/components/layout/cart-drawer.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/hooks/use-cart";
 import { ProductMedia } from "@/components/ui/product-media";
 import { formatPrice } from "@/lib/format";
+import { cartSizeLabel } from "@/lib/size-display";
 import type { CartItem } from "@/types";
 
 export function CartDrawer() {
@@ -153,7 +154,8 @@ function CartItems({
   return (
     <div className="flex flex-col gap-6">
       {items.map((item) => {
-        const { product, quantity, size, sizeLabel } = item;
+        const { product, quantity, size } = item;
+        const shownSize = cartSizeLabel(item);
         const formattedPrice = formatPrice(product.price * quantity);
 
         return (
@@ -179,10 +181,10 @@ function CartItems({
                 </p>
               </div>
               <div className="flex items-center justify-between">
-                {size && (
+                {shownSize && (
                   <span className="text-black text-xl leading-6 font-medium tracking-[0.01em]">
                     <span className="hidden lg:inline">Розмір: </span>
-                    {sizeLabel ?? size}
+                    {shownSize}
                   </span>
                 )}
                 <div className="flex items-center gap-3 ml-auto">

--- a/components/product/product-page-content.tsx
+++ b/components/product/product-page-content.tsx
@@ -129,13 +129,14 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
                 {formattedPrice}
               </p>
             </div>
-            <div className="mt-6">
-              <SizeSelector
-                sizes={product.sizes}
-                selectedSize={selectedSize?.value ?? null}
-                onSelect={setSelectedSize}
-              />
-            </div>
+            {/* No wrapper: an empty one would leave its own gap behind on a
+                product whose selector renders nothing. The selector carries the
+                spacing itself. */}
+            <SizeSelector
+              sizes={product.sizes}
+              selectedSize={selectedSize?.value ?? null}
+              onSelect={setSelectedSize}
+            />
           </div>
         </div>
 

--- a/components/product/size-selector.tsx
+++ b/components/product/size-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChipButton } from "@/components/ui/chip-button";
+import { sizeIsAChoice } from "@/lib/size-display";
 import type { ProductSize } from "@/types";
 
 interface SizeSelectorProps {
@@ -14,13 +15,20 @@ interface SizeSelectorProps {
  * The sizes a product is made in. A size KeyCRM has none of stays on screen —
  * struck through and unclickable — because a missing chip reads as "we do not
  * make that size" rather than "it is out this week".
+ *
+ * A single size is not a choice, so it is not drawn — see lib/size-display.ts,
+ * which the cart and the checkout read too. The size itself is still picked and
+ * still travels to the cart and the order — ProductPageContent pre-selects the
+ * first size in stock — so hiding it here costs the KeyCRM offer match nothing.
+ * And a lone size that is out of stock needs no chip either: the button already
+ * says so.
  */
 export function SizeSelector({
   sizes,
   selectedSize,
   onSelect,
 }: SizeSelectorProps) {
-  if (!sizes || sizes.length === 0) return null;
+  if (!sizeIsAChoice(sizes)) return null;
 
   return (
     <div className="flex gap-3 overflow-x-auto mt-6 lg:mt-10 pb-1 scrollbar-hide px-5 lg:px-0 lg:flex-wrap lg:gap-4">

--- a/lib/size-display.ts
+++ b/lib/size-display.ts
@@ -1,0 +1,40 @@
+// Whether a size is worth showing the customer at all.
+//
+// A size is information only when it was a choice. Straps and wraps come in one
+// size, and printing that size — "Універсальний", or whatever KeyCRM happens to
+// call it — tells the customer nothing they did not already know, while adding a
+// chip that is permanently selected and a cart line that answers a question
+// nobody asked. Belts are the opposite: which of five widths is in the cart is
+// the single most important thing on the line.
+//
+// So the rule is "more than one size", not "the size is named X". Renaming the
+// KeyCRM offer would only move the problem to the next product, and matching on
+// the word would break the first time somebody types "універсальний" in lower
+// case. The size itself still travels to the order regardless — this decides
+// nothing but what is drawn.
+//
+// It lives here so the product page, the cart drawer and the checkout summary
+// cannot disagree: a size hidden on one screen and shown on the next reads as a
+// bug, and the checkout is the worst place to first mention a size the customer
+// never picked.
+
+import type { CartItem, ProductSize } from "@/types";
+
+/**
+ * True when the product is made in more than one size, i.e. picking one is real.
+ *
+ * Typed as a predicate so a caller that guards on it can go on to map the list
+ * without a second undefined check.
+ */
+export function sizeIsAChoice(sizes?: ProductSize[]): sizes is ProductSize[] {
+  return (sizes?.length ?? 0) > 1;
+}
+
+/**
+ * What to print for a cart line's size, or null when the size is not a choice
+ * and should be left off the screen entirely.
+ */
+export function cartSizeLabel(item: CartItem): string | null {
+  if (!sizeIsAChoice(item.product.sizes)) return null;
+  return item.sizeLabel ?? item.size ?? null;
+}


### PR DESCRIPTION
## Що це

Лямки-вісімки універсальні, але в KeyCRM вони досі заведені через властивість «Розмір». На сайті це давало:

- на сторінці товару — один чіп, який уже обраний і нічого не робить при кліку;
- у кошику й на чекауті — рядок «Розмір: M», тобто розмір, якого ніхто не обирав, названий складською літерою.

Тепер розмір показується тільки тоді, коли їх більше одного.

## Як

Правило живе в одному новому модулі `lib/size-display.ts`, який читають усі три екрани — сторінка товару, `cart-drawer`, `order-summary`. Розділяти його не можна: розмір, прихований на одному екрані й показаний на наступному, читається як баг, а чекаут — найгірше місце вперше згадати розмір, якого клієнт не обирав.

Правило — «більше ніж один розмір», а не «розмір називається Універсальний». Матчинг по слову зламався б на першому ж товарі, названому інакше, або на написанні з малої літери.

## Що не змінилося

- Пояси й наколінники — без змін, усі чіпи на місці, включно з перекресленими (немає в наявності).
- Замовлення — теж без змін: `ProductPageContent` так само передвибирає перший розмір у наявності, значення так само доїжджає в кошик, і `lib/orders.ts` так само зіставляє його з пропозицією KeyCRM. Ця зміна вирішує тільки те, що малюється.

## Найтонше місце

Компактний мобільний блок на чекауті ніс у одній умові і розмір, і хвіст «та ще N товари» — приховування розміру забрало б хвіст із собою. Тепер вони незалежні.

## Перевірено

На дев-сервері, з тимчасово змодельованим станом «одна пропозиція» (патч прибрано, у діфі його немає):

- сторінка товару: у лямок чисто, у пояса всі чотири чіпи;
- кошик: у лямок рядка розміру немає, у пояса «Розмір: 57.5-70 см»;
- чекаут десктоп і мобільний: те саме, «та ще 1 товар» на місці;
- додавання в кошик без чіпа кладе `"size": "M"` — розмір їде в замовлення;
- `tsc --noEmit` і eslint по змінених файлах — чисто.

## Супутнє (поза кодом)

У KeyCRM усі чотири лямки вже зведені під один варіант: залишки L перенесено на M і L заархівовано — Blue 61, Red 75, Black 50, Pink 32. Резерви (1/1/8/6) були на M і не постраждали. Перейменувати значення на «Універсальний» KeyCRM не дозволяє — редагується лише назва властивості, — тож усередині CRM варіант лишається «Розмір: M»; клієнт цього не бачить саме завдяки цьому PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)