### PR TITLE
Нова сторінка товару: блок відправки, розміри з літерами, опис і історія дизайну

### DIFF
--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { ProductPageContent } from "@/components/product/product-page-content";
 import { ProductImagesSection } from "@/components/product/product-images-section";
+import { ProductDetailsSection } from "@/components/product/product-details-section";
+import { beltAttributes } from "@/content/belt-attributes";
 import { RelatedProducts } from "@/components/product/related-products";
 import { FAQSection } from "@/components/sections/faq-section";
 import { BenefitsGrid } from "@/components/sections/benefits-grid";
@@ -84,7 +86,13 @@ export default async function ProductPage({ params }: Props) {
       />
       <Header />
       <ProductPageContent product={product} />
-      <ProductImagesSection images={product.galleryImages || []} />
+      <ProductImagesSection
+        images={product.galleryImages || []}
+        // Belts only, for now: the other categories keep the plain photo grid
+        // until they get copy of their own.
+        attributes={product.category === "belts" ? beltAttributes : undefined}
+      />
+      <ProductDetailsSection product={product} />
       <RelatedProducts
         products={relatedProducts}
         categorySlug={category?.slug}

--- a/components/product/dispatch-badge.tsx
+++ b/components/product/dispatch-badge.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * «Відправимо сьогодні» — the green pulsing dot over the product name.
+ *
+ * Drawn only while something can actually be dispatched: the caller passes
+ * whether the product is in stock, and a sold-out page shows nothing rather
+ * than a promise next to a dead button.
+ */
+export function DispatchBadge({ className }: { className?: string }) {
+  return (
+    <p
+      className={cn(
+        "flex items-center gap-2 font-sans text-xs lg:text-sm font-bold leading-4 lg:leading-5 tracking-[0.03em] uppercase text-[#2DB87A]",
+        className
+      )}
+    >
+      <span className="relative inline-flex size-4 shrink-0" aria-hidden>
+        <span className="absolute inset-0 rounded-full bg-[#2DB87A]/48 motion-safe:animate-ping motion-safe:[animation-duration:2.4s]" />
+        <span className="absolute inset-0 rounded-full bg-[#2DB87A]/48" />
+        <span className="absolute inset-[5px] rounded-full bg-[#2DB87A]" />
+      </span>
+      Відправимо сьогодні
+    </p>
+  );
+}

--- a/components/product/product-attributes.tsx
+++ b/components/product/product-attributes.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+interface ProductAttributesProps {
+  items: string[];
+  className?: string;
+}
+
+/** The bullet list that sits between the two rows of product photos. */
+export function ProductAttributes({ items, className }: ProductAttributesProps) {
+  return (
+    <ul
+      className={cn(
+        "grid grid-cols-1 gap-8 px-4 py-6 lg:grid-cols-2 lg:gap-x-20 lg:gap-y-20 lg:px-[72px] lg:py-[72px]",
+        className
+      )}
+    >
+      {items.map((text) => (
+        <li
+          key={text}
+          className="flex items-start gap-3 lg:gap-6 font-heading font-bold text-white text-base leading-6 tracking-[0.02em] lg:text-2xl lg:leading-8"
+        >
+          <span
+            aria-hidden
+            className="mt-[9px] size-1.5 shrink-0 rounded-full bg-primary lg:mt-[10px] lg:size-3"
+          />
+          <span>{text}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/product/product-details-section.tsx
+++ b/components/product/product-details-section.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { productDetailItems } from "./product-info-items";
+import { ProductInfoAccordion } from "./product-info-accordion";
+import type { Product } from "@/types";
+
+/**
+ * Description, design story and care — the wide rows under the photos.
+ *
+ * Desktop only: on mobile the same panels sit under the hero card, before the
+ * photos, where ProductPageContent draws them. Two placements for one list is
+ * the design; one component in two places is how they stay one list.
+ */
+export function ProductDetailsSection({ product }: { product: Product }) {
+  const items = productDetailItems(product);
+  if (items.length === 0) return null;
+
+  return (
+    <section className="hidden lg:block bg-black pt-4">
+      <div className="container-main">
+        <ProductInfoAccordion items={items} variant="wide" />
+      </div>
+    </section>
+  );
+}

--- a/components/product/product-images-section.tsx
+++ b/components/product/product-images-section.tsx
@@ -3,28 +3,71 @@
 import { ProductMedia } from "@/components/ui/product-media";
 import { FadeUp } from "@/components/ui/fade-up";
 import type { ProductImage } from "@/types";
+import { ProductAttributes } from "./product-attributes";
 
 interface ProductImagesSectionProps {
   images: ProductImage[];
+  /**
+   * When given, the bullet list is slotted in after the first two photos and
+   * the remaining photos follow it — the belt layout. Without it the photos
+   * simply run in pairs.
+   */
+  attributes?: string[];
 }
 
-export function ProductImagesSection({ images }: ProductImagesSectionProps) {
+const FRAME_CLASS =
+  "relative aspect-[374/467] md:aspect-[696/870] rounded-3xl md:rounded-[48px] overflow-hidden";
+
+export function ProductImagesSection({
+  images,
+  attributes,
+}: ProductImagesSectionProps) {
   if (images.length === 0) return null;
+
+  const hasAttributes = Boolean(attributes?.length);
+  const firstRow = hasAttributes ? images.slice(0, 2) : images;
+  const secondRow = hasAttributes ? images.slice(2, 4) : [];
+  // A belt is meant to have four photos. Three is a photo still to be shot, so
+  // the fourth slot is kept as an empty frame — as the design draws it — rather
+  // than letting one photo sit alone at full width and pretend to be the
+  // layout.
+  const secondRowPlaceholders =
+    secondRow.length === 1 ? [null] : ([] as null[]);
 
   return (
     <section className="bg-black lg:pt-4">
-      <div className="container-main [--container-px:0.5rem] md:[--container-px:clamp(1.5rem,5vw,2rem)]">
+      <div className="container-main [--container-px:0.5rem] md:[--container-px:clamp(1.5rem,5vw,2rem)] flex flex-col gap-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {images.map((image, index) => (
-            <FadeUp
-              key={index}
-              delay={index * 0.15}
-              className="relative aspect-[696/870] rounded-3xl md:rounded-[48px] overflow-hidden"
-            >
+          {firstRow.map((image, index) => (
+            <FadeUp key={index} delay={index * 0.15} className={FRAME_CLASS}>
               <ProductMedia image={image} fill className="object-cover" />
             </FadeUp>
           ))}
         </div>
+
+        {hasAttributes && (
+          <FadeUp>
+            <ProductAttributes items={attributes!} />
+          </FadeUp>
+        )}
+
+        {secondRow.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {secondRow.map((image, index) => (
+              <FadeUp key={index} delay={index * 0.15} className={FRAME_CLASS}>
+                <ProductMedia image={image} fill className="object-cover" />
+              </FadeUp>
+            ))}
+            {secondRowPlaceholders.map((_, index) => (
+              <FadeUp
+                key={`placeholder-${index}`}
+                delay={0.15}
+                className={`${FRAME_CLASS} bg-surface`}
+                aria-hidden
+              />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/components/product/product-info-accordion.tsx
+++ b/components/product/product-info-accordion.tsx
@@ -7,42 +7,65 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from "@/components/ui/accordion";
+import type { ProductInfoItem } from "./product-info-items";
 
 interface ProductInfoAccordionProps {
-  description?: string;
-  howToMeasure?: string;
-  careInstructions?: string;
+  items: ProductInfoItem[];
+  /**
+   * `compact` is the hero card's translucent panel (and the mobile stack);
+   * `wide` is the full-width row under the photos on desktop, sized like the
+   * FAQ section so the two read as one system.
+   */
+  variant?: "compact" | "wide";
   itemClassName?: string;
+  className?: string;
 }
 
 export function ProductInfoAccordion({
-  description,
-  howToMeasure,
-  careInstructions,
+  items,
+  variant = "compact",
   itemClassName,
+  className,
 }: ProductInfoAccordionProps) {
-  const items = [
-    { id: "description", title: "Опис товару", content: description },
-    { id: "measure", title: "Як правильно міряти?", content: howToMeasure },
-    {
-      id: "care",
-      title: "Інструкція з догляду",
-      content: careInstructions,
-    },
-  ].filter((item) => item.content);
+  if (items.length === 0) return null;
+
+  const wide = variant === "wide";
 
   return (
-    <Accordion type="single" collapsible className="flex flex-col gap-4">
+    <Accordion
+      type="single"
+      collapsible
+      className={cn("flex flex-col gap-4", className)}
+    >
       {items.map((item) => (
         <AccordionItem
           key={item.id}
           value={item.id}
-          className={cn("bg-[#0000007A] backdrop-blur-sm rounded-3xl border-none px-5", itemClassName)}
+          className={cn(
+            "rounded-3xl border-none",
+            wide
+              ? "bg-surface px-6 lg:px-12"
+              : "bg-[#0000007A] backdrop-blur-sm px-6",
+            itemClassName
+          )}
         >
-          <AccordionTrigger className="text-white font-heading text-base leading-6 font-bold tracking-[0.03em] py-6 cursor-pointer">
+          <AccordionTrigger
+            className={cn(
+              "text-white font-heading font-bold cursor-pointer hover:no-underline",
+              wide
+                ? "text-base leading-6 tracking-[0.03em] py-5 lg:text-2xl lg:leading-8 lg:tracking-[0.02em] lg:py-10 data-[state=open]:lg:pb-4"
+                : "text-base leading-6 tracking-[0.02em] lg:tracking-[0.03em] py-5 lg:py-6"
+            )}
+          >
             {item.title}
           </AccordionTrigger>
-          <AccordionContent className="text-white text-base lg:text-lg">
+          <AccordionContent
+            className={cn(
+              // Strapi long-text keeps its paragraph breaks as blank lines.
+              "text-white text-base lg:text-lg whitespace-pre-line",
+              wide ? "pb-5 lg:pb-12" : "pb-5 lg:pb-6"
+            )}
+          >
             {item.content}
           </AccordionContent>
         </AccordionItem>

--- a/components/product/product-info-items.ts
+++ b/components/product/product-info-items.ts
@@ -1,0 +1,35 @@
+import type { Product } from "@/types";
+
+export interface ProductInfoItem {
+  id: string;
+  title: string;
+  content: string;
+}
+
+/**
+ * The size guide, on its own: it sits beside the size chips in the hero on
+ * desktop and heads the list on mobile.
+ */
+export function sizeGuideItem(product: Product): ProductInfoItem | null {
+  return product.howToMeasure
+    ? { id: "measure", title: "Як визначити розмір?", content: product.howToMeasure }
+    : null;
+}
+
+/**
+ * The panels that describe the product — under the photos on desktop, under
+ * the size guide on mobile. Anything the product has no text for is left out
+ * rather than drawn empty.
+ */
+export function productDetailItems(product: Product): ProductInfoItem[] {
+  const isBelt = product.category === "belts";
+  return [
+    {
+      id: "description",
+      title: isBelt ? "Опис поясу" : "Опис товару",
+      content: product.description,
+    },
+    { id: "story", title: "Історія дизайну", content: product.designStory },
+    { id: "care", title: "Інструкція з догляду", content: product.careInstructions },
+  ].filter((item): item is ProductInfoItem => Boolean(item.content));
+}

--- a/components/product/product-page-content.tsx
+++ b/components/product/product-page-content.tsx
@@ -11,6 +11,8 @@ import { formatPriceWithCurrency } from "@/lib/format";
 import type { Product, ProductSize } from "@/types";
 import { SizeSelector } from "./size-selector";
 import { ProductInfoAccordion } from "./product-info-accordion";
+import { productDetailItems, sizeGuideItem } from "./product-info-items";
+import { DispatchBadge } from "./dispatch-badge";
 import { ModelViewer } from "@/components/models/model-viewer";
 import { ProductMedia } from "@/components/ui/product-media";
 import { CTAButton } from "@/components/ui/cta-button";
@@ -75,6 +77,18 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
   const mobile3d = show3dModel && isHydrated && !isDesktop;
   const desktop3d = show3dModel && isHydrated && isDesktop;
 
+  // Desktop keeps the size guide in the hero and pushes the rest under the
+  // photos (ProductDetailsSection); mobile stacks everything under the card.
+  // The mobile design also puts the design story last, after care, while the
+  // desktop rows go description → story → care, so the order is not shared.
+  const sizeGuide = sizeGuideItem(product);
+  const details = productDetailItems(product);
+  const mobileInfoItems = [
+    ...(sizeGuide ? [sizeGuide] : []),
+    ...details.filter((item) => item.id !== "story"),
+    ...details.filter((item) => item.id === "story"),
+  ];
+
   const handleAddToCart = () => {
     if (soldOut) return;
     addItem(product, selectedSize?.value, selectedSize?.label);
@@ -122,10 +136,11 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
           {/* Name / price / sizes */}
           <div className="relative z-10 pt-2 pb-6 bg-gradient-to-t from-black/70 to-transparent">
             <div className="px-5">
-              <h1 className="font-heading text-h3 font-bold text-white">
+              {!soldOut && <DispatchBadge className="mb-3" />}
+              <h1 className="font-heading text-h2 font-bold text-white tracking-[0.01em]">
                 {product.name}
               </h1>
-              <p className="font-heading text-h3 font-bold text-white mt-4">
+              <p className="font-heading text-h2 font-bold text-white tracking-[0.01em] mt-4">
                 {formattedPrice}
               </p>
             </div>
@@ -143,10 +158,8 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
         {/* Accordion below card */}
         <div className="mt-4 px-2 md:px-4">
           <ProductInfoAccordion
-            description={product.description}
-            howToMeasure={product.howToMeasure}
-            careInstructions={product.careInstructions}
-            itemClassName="bg-[#141414] backdrop-blur-none"
+            items={mobileInfoItems}
+            itemClassName="bg-surface backdrop-blur-none"
           />
         </div>
       </div>
@@ -210,6 +223,7 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
                   transition={{ duration: 0.6, delay: 0.2 }}
                   className="flex flex-col pointer-events-auto"
                 >
+                  {!soldOut && <DispatchBadge className="mb-2" />}
                   <h1 className="font-heading text-h2 font-bold text-white tracking-normal">
                     {product.name}
                   </h1>
@@ -230,11 +244,7 @@ export function ProductPageContent({ product }: ProductPageContentProps) {
                   transition={{ duration: 0.6, delay: 0.4 }}
                   className="flex flex-col gap-4 w-[420px] pointer-events-auto"
                 >
-                  <ProductInfoAccordion
-                    description={product.description}
-                    howToMeasure={product.howToMeasure}
-                    careInstructions={product.careInstructions}
-                  />
+                  {sizeGuide && <ProductInfoAccordion items={[sizeGuide]} />}
                   <CTAButton
                     width="fill"
                     onClick={handleAddToCart}

--- a/components/product/size-selector.tsx
+++ b/components/product/size-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChipButton } from "@/components/ui/chip-button";
-import { sizeIsAChoice } from "@/lib/size-display";
+import { sizeDisplayText, sizeIsAChoice } from "@/lib/size-display";
 import type { ProductSize } from "@/types";
 
 interface SizeSelectorProps {
@@ -40,7 +40,7 @@ export function SizeSelector({
           disabled={!size.inStock}
           title={size.inStock ? undefined : "Немає в наявності"}
         >
-          {size.label}
+          {sizeDisplayText(size.value, size.label)}
         </ChipButton>
       ))}
     </div>

--- a/components/product/size-selector.tsx
+++ b/components/product/size-selector.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useRef } from "react";
 import { ChipButton } from "@/components/ui/chip-button";
+import { useScrollHint } from "@/hooks/use-scroll-hint";
 import { sizeDisplayText, sizeIsAChoice } from "@/lib/size-display";
 import type { ProductSize } from "@/types";
 
@@ -28,10 +30,16 @@ export function SizeSelector({
   selectedSize,
   onSelect,
 }: SizeSelectorProps) {
+  // On a phone the chips run off the right edge; the row creeps along once so
+  // the cut-off chip reads as "more this way" and not as the end of the list.
+  // On desktop the row wraps, nothing overflows, and the hook does nothing.
+  const rowRef = useRef<HTMLDivElement>(null);
+  useScrollHint(rowRef);
+
   if (!sizeIsAChoice(sizes)) return null;
 
   return (
-    <div className="flex gap-3 overflow-x-auto mt-6 lg:mt-10 pb-1 scrollbar-hide px-5 lg:px-0 lg:flex-wrap lg:gap-4">
+    <div ref={rowRef} className="flex gap-3 overflow-x-auto mt-6 lg:mt-10 pb-1 scrollbar-hide px-5 lg:px-0 lg:flex-wrap lg:gap-4">
       {sizes.map((size) => (
         <ChipButton
           key={size.value}

--- a/content/belt-attributes.ts
+++ b/content/belt-attributes.ts
@@ -1,0 +1,17 @@
+// The bullet list between the belt photos on a belt's product page.
+//
+// Every INVITUS belt is the same belt underneath the artwork — 10 mm, four
+// layers, lever — so this is category copy, not product copy, and lives here
+// rather than in Strapi. The per-product `attributes` component in Strapi
+// ("Товщина: 10 мм") holds the same facts as terse pairs; the design asks for
+// sentences, and repeating six identical sentences across twenty entries would
+// be twenty places to edit the next time the leather changes.
+
+export const beltAttributes: string[] = [
+  "Товщина 10 мм",
+  "Виготовлений зі 100% натуральної шкіри",
+  "Важільна застібка — розмір налаштовується один раз",
+  "Складається з 4 шарів шкіри",
+  "Підходить для присідань, станової тяги та інших силових вправ",
+  "Внутрішній шар із замші забезпечує комфорт",
+];

--- a/content/product-extras.ts
+++ b/content/product-extras.ts
@@ -41,8 +41,17 @@ export interface ProductExtras {
   bgImage?: ProductImage;
   /** Gallery rendered below the product; overrides KeyCRM attachments when present. */
   galleryImages?: ProductImage[];
+  /**
+   * Marketing copy for the product. KeyCRM has a description field too, but it
+   * is empty on every belt, and a manager editing it there would be editing the
+   * wrong system — the description is presentation, so Strapi wins when it has
+   * one and KeyCRM's is only the fallback.
+   */
+  description?: string;
   howToMeasure?: string;
   careInstructions?: string;
+  /** The story behind the design, shown as its own panel under the photos. */
+  designStory?: string;
   /**
    * Emergency fallback for the homepage sections only.
    *

--- a/hooks/use-scroll-hint.ts
+++ b/hooks/use-scroll-hint.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Creeps a horizontally scrollable row to its end, slowly enough to read as
+ * "this moves" rather than as motion for its own sake.
+ *
+ * A row of chips that is cut off at the screen edge looks finished — nothing
+ * says the rest is there. Scrolling it a little on the user's behalf does. It
+ * runs once, only when the row actually overflows, and hands control back the
+ * moment the user touches it: a hint that keeps going after the user has
+ * understood it is a fight over the scrollbar. Reduced motion skips it.
+ */
+export function useScrollHint(
+  ref: RefObject<HTMLElement | null>,
+  {
+    pixelsPerSecond = 18,
+    delayMs = 900,
+  }: { pixelsPerSecond?: number; delayMs?: number } = {}
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (el.scrollWidth - el.clientWidth < 8) return;
+
+    let frame = 0;
+    let stopped = false;
+    let last = 0;
+    let position = el.scrollLeft;
+
+    const stop = () => {
+      stopped = true;
+      cancelAnimationFrame(frame);
+    };
+    const step = (now: number) => {
+      if (stopped) return;
+      if (last) {
+        position += ((now - last) / 1000) * pixelsPerSecond;
+        el.scrollLeft = position;
+      }
+      last = now;
+      if (el.scrollLeft + el.clientWidth >= el.scrollWidth - 1) return;
+      frame = requestAnimationFrame(step);
+    };
+
+    // Any input on the row is the user taking over, including a scroll that
+    // is not ours (a fling from the touch events we already watch).
+    const takeover: (keyof HTMLElementEventMap)[] = [
+      "pointerdown",
+      "touchstart",
+      "wheel",
+    ];
+    for (const type of takeover) el.addEventListener(type, stop, { passive: true });
+
+    const timer = window.setTimeout(() => {
+      frame = requestAnimationFrame(step);
+    }, delayMs);
+
+    return () => {
+      stop();
+      window.clearTimeout(timer);
+      for (const type of takeover) el.removeEventListener(type, stop);
+    };
+  }, [ref, pixelsPerSecond, delayMs]);
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -175,9 +175,12 @@ function toProduct(
     price: p.min_price,
     category: category ? categorySlug(category) : undefined,
 
-    description: p.description ?? undefined,
+    // Strapi first: KeyCRM's description is empty on every belt, and the copy
+    // is presentation, which Strapi owns. See ProductExtras.description.
+    description: extras?.description ?? p.description ?? undefined,
     howToMeasure: extras?.howToMeasure,
     careInstructions: extras?.careInstructions,
+    designStory: extras?.designStory,
 
     mainImage,
     heroImage,

--- a/lib/product-extras.ts
+++ b/lib/product-extras.ts
@@ -34,12 +34,7 @@
 // deliberately long: the fewer times we touch Strapi, the fewer chances a blip
 // there has to become a visible bug here.
 
-import { getStrapiMedia } from "./strapi";
-import {
-  strapiAuthHeaders,
-  strapiGetWithRetries,
-  StrapiNotFoundError,
-} from "./strapi-fetch";
+import { getStrapiURL, getStrapiMedia } from "./strapi";
 import { slugify } from "./slugify";
 import type {
   StrapiHomepage,
@@ -82,7 +77,7 @@ export const STRAPI_EXTRAS_TAG = "strapi-extras";
 // the wake-up, so the retry is usually the fast case.
 const ATTEMPT_TIMEOUT_MS = 12_000;
 const MAX_ATTEMPTS = 3;
-const ATTEMPT_TIMEOUTS_MS = Array<number>(MAX_ATTEMPTS).fill(ATTEMPT_TIMEOUT_MS);
+const RETRY_DELAY_MS = 1_000;
 
 // Safety net for a missed webhook, not the freshness mechanism. See the note
 // at the top of this file.
@@ -172,8 +167,10 @@ async function fetchStrapiExtras(): Promise<ExtrasIndex> {
             }
           : undefined,
         galleryImages: galleryImages.length ? galleryImages : undefined,
+        description: p.description ?? undefined,
         howToMeasure: p.howToMeasure ?? undefined,
         careInstructions: p.careInstructions ?? undefined,
+        designStory: p.designStory ?? undefined,
         featured: p.featured || undefined,
         // Strapi's integer field defaults to 0, and 0 is a position like any
         // other; only a genuinely absent value means "no opinion, sort last".
@@ -230,13 +227,10 @@ const HOMEPAGE_QUERY =
  * the fallback render.
  */
 async function fetchWithRetries(): Promise<StrapiResponse<StrapiProduct[]>> {
-  return strapiGetWithRetries<StrapiResponse<StrapiProduct[]>>({
-    query: PRODUCTS_QUERY,
-    tag: STRAPI_EXTRAS_TAG,
-    timeouts: ATTEMPT_TIMEOUTS_MS,
-    revalidate: REVALIDATE_S,
-    logPrefix: "[extras]",
-  });
+  return getWithRetries<StrapiResponse<StrapiProduct[]>>(
+    PRODUCTS_QUERY,
+    "extras"
+  );
 }
 
 /**
@@ -256,29 +250,24 @@ async function fetchHomepage(): Promise<HomepageLists> {
   if (Date.now() < homepageSkipUntil) return lastGood?.homepage ?? EMPTY_HOMEPAGE;
 
   try {
-    const json = await strapiGetWithRetries<
-      StrapiResponse<StrapiHomepage | null>
-    >({
-      query: HOMEPAGE_QUERY,
-      tag: STRAPI_EXTRAS_TAG,
-      timeouts: ATTEMPT_TIMEOUTS_MS,
-      revalidate: REVALIDATE_S,
-      logPrefix: "[homepage]",
+    const json = await getWithRetries<StrapiResponse<StrapiHomepage | null>>(
+      HOMEPAGE_QUERY,
+      "homepage",
       // Products are readable anonymously; the `Homepage` single type is not —
       // its find permission is granted to the API token, and an unauthenticated
       // read gets a 403 that would leave the homepage on the `featured`
       // fallback forever. Only this query carries the token: putting the
       // products query behind a second auth surface would add a way for
       // something that works today to start failing, and buy nothing.
-      headers: strapiAuthHeaders(),
-    });
+      strapiAuthHeaders()
+    );
     return {
       showcase: toProductRefs(json.data?.showcase) ?? [],
       shopCta: toProductRefs(json.data?.shopCta) ?? [],
     };
   } catch (error) {
     homepageSkipUntil = Date.now() + FAILURE_BACKOFF_MS;
-    if (!(error instanceof StrapiNotFoundError)) {
+    if (!(error instanceof NotFoundError)) {
       const reason = error instanceof Error ? error.message : String(error);
       console.warn(
         `Strapi homepage fetch failed (${reason}), ` +
@@ -288,6 +277,58 @@ async function fetchHomepage(): Promise<HomepageLists> {
     return lastGood?.homepage ?? EMPTY_HOMEPAGE;
   }
 }
+
+/** Server-only module, so the token never reaches the client bundle. */
+function strapiAuthHeaders(): Record<string, string> {
+  const token = process.env.STRAPI_API_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function getWithRetries<T>(
+  query: string,
+  label: string,
+  headers: Record<string, string> = {}
+): Promise<T> {
+  const url = getStrapiURL(query);
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
+        next: { revalidate: REVALIDATE_S, tags: [STRAPI_EXTRAS_TAG] },
+      });
+
+      if (response.status === 404) {
+        throw new NotFoundError(`Strapi responded 404`);
+      }
+      if (response.status >= 400 && response.status < 500) {
+        throw new NonRetryableError(`Strapi responded ${response.status}`);
+      }
+      if (!response.ok) throw new Error(`Strapi responded ${response.status}`);
+
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof NonRetryableError) throw error;
+      lastError = error;
+      if (attempt < MAX_ATTEMPTS) {
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `Strapi ${label} attempt ${attempt}/${MAX_ATTEMPTS} failed (${reason}), retrying`
+        );
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+class NonRetryableError extends Error {}
+/** A 4xx that carries meaning: the single type has no saved entry yet. */
+class NotFoundError extends NonRetryableError {}
 
 /**
  * Strapi relation entries → unresolved pointers. Returns undefined for an empty

--- a/lib/size-display.test.ts
+++ b/lib/size-display.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { cartSizeLabel, sizeDisplayText, sizeIsAChoice } from "./size-display.ts";
+import type { CartItem, Product } from "@/types";
+
+const belt = {
+  id: "1",
+  name: "Belt",
+  sizes: [
+    { value: "S", label: "65-80 см", inStock: true },
+    { value: "M", label: "72.5-90 см", inStock: true },
+  ],
+} as unknown as Product;
+
+const strap = {
+  id: "2",
+  name: "Strap",
+  sizes: [{ value: "Універсальний", label: "Універсальний", inStock: true }],
+} as unknown as Product;
+
+describe("sizeDisplayText", () => {
+  it("joins the KeyCRM letter with the Strapi range", () => {
+    assert.equal(sizeDisplayText("S", "65-80 см"), "S · 65-80 см");
+  });
+
+  it("does not repeat a size that has no separate wording", () => {
+    assert.equal(sizeDisplayText("S", "S"), "S");
+  });
+});
+
+describe("cartSizeLabel", () => {
+  it("prints the same text as the product page chip", () => {
+    const item: CartItem = {
+      product: belt,
+      quantity: 1,
+      size: "S",
+      sizeLabel: "65-80 см",
+    };
+    assert.equal(cartSizeLabel(item), "S · 65-80 см");
+  });
+
+  it("falls back to the value when the label was never stored", () => {
+    const item: CartItem = { product: belt, quantity: 1, size: "M" };
+    assert.equal(cartSizeLabel(item), "M");
+  });
+
+  it("is silent for a one-size product", () => {
+    assert.equal(sizeIsAChoice(strap.sizes), false);
+    const item: CartItem = {
+      product: strap,
+      quantity: 1,
+      size: "Універсальний",
+    };
+    assert.equal(cartSizeLabel(item), null);
+  });
+});

--- a/lib/size-display.ts
+++ b/lib/size-display.ts
@@ -31,10 +31,25 @@ export function sizeIsAChoice(sizes?: ProductSize[]): sizes is ProductSize[] {
 }
 
 /**
+ * The text a size is drawn as: "S · 65-80 см".
+ *
+ * A belt is stocked by letter but fits by waist, and the customer needs both —
+ * the range to pick by, the letter to recognise the belt they already own or
+ * to say to a manager. When Strapi has no wording for a size the label is the
+ * value itself, and printing "S · S" would look like a bug, so it collapses to
+ * the one string.
+ */
+export function sizeDisplayText(value: string, label: string): string {
+  return label === value ? value : `${value} · ${label}`;
+}
+
+/**
  * What to print for a cart line's size, or null when the size is not a choice
- * and should be left off the screen entirely.
+ * and should be left off the screen entirely. Same text as the product page
+ * chip, so the cart names the size the customer just clicked.
  */
 export function cartSizeLabel(item: CartItem): string | null {
   if (!sizeIsAChoice(item.product.sizes)) return null;
-  return item.sizeLabel ?? item.size ?? null;
+  if (!item.size) return null;
+  return sizeDisplayText(item.size, item.sizeLabel ?? item.size);
 }

--- a/lib/strapi-schema.ts
+++ b/lib/strapi-schema.ts
@@ -100,6 +100,8 @@ export interface StrapiProduct {
   shortDescription: string | null;
   howToMeasure: string | null;
   careInstructions: string | null;
+  /** Long text; absent until the field is added to the Strapi content type. */
+  designStory?: string | null;
   featured: boolean;
   order: number;
   seoTitle: string | null;

--- a/types/index.ts
+++ b/types/index.ts
@@ -56,6 +56,8 @@ export interface Product {
   shortDescription?: string;
   howToMeasure?: string;
   careInstructions?: string;
+  /** The story behind the design — the artwork, the name. Strapi-only. */
+  designStory?: string;
 
   mainImage?: ProductImage;
   heroImage?: ProductImage;


### PR DESCRIPTION
Сторінка товару за макетом [Figma 1391-8050](https://www.figma.com/design/MsYv7oeA9QSB5PSl9f6RJm/Invitus-Digital?node-id=1391-8050) (десктоп) і [1382-6729](https://www.figma.com/design/MsYv7oeA9QSB5PSl9f6RJm/Invitus-Digital?node-id=1382-6729) (мобільний).

## Що всередині

- **«Відправимо сьогодні»** над назвою, з пульсуючою крапкою. Малюється лише коли товар справді в наявності: обіцянка відправки поруч із мертвою кнопкою гірша за її відсутність.
- **Розміри з літерами.** Чіп тепер «S · 65-80 см». Обидві половини вже були в `ProductSize`, просто одну з них викидали. Склеювання живе в `sizeDisplayText` поруч із правилом про те, коли розмір узагалі варто показувати, бо кошик і чекаут друкують той самий рядок.
- **Підказка про прокрутку.** На телефоні п'ять розмірів не влазять, і обрізаний ряд виглядає як кінець списку. Тепер він повільно проїжджає до кінця сам і зупиняється назавжди від першого дотику. Поважає `prefers-reduced-motion`, на десктопі не робить нічого.
- **Панелі переїхали.** На десктопі в героїблоці лишився тільки гайд по розміру, поруч із чіпами, які він пояснює. Опис, історія дизайну та догляд стали широкими рядами під фото. На мобільному всі чотири під карткою, історія остання.
- **Перейменування.** «Як правильно міряти?» → «Як визначити розмір?», опис на поясі → «Опис поясу».
- **Список атрибутів** між двома рядами фото, поки лише для поясів.
- **Чотири фото** на сторінці пояса: два, атрибути, ще два. Якщо фото три, четвертий слот лишається порожньою рамкою, як у макеті.

## Дані

`description` тепер береться зі Strapi, а KeyCRM лише запасний варіант. Причина проста: у KeyCRM це поле порожнє в усіх без винятку поясів, тому панель опису на поясі не рендерилась ніколи. Поле `designStory` нове, схема вже задеплоєна, тексти залиті для 16 поясів.

Шість поясів (Guts, Military, Custom, Blue, Red, Green) не мають записів у Strapi, тому в них цієї панелі не буде, доки записи не створять. Панелі без тексту просто не малюються.

Окремо: запис Silence у Strapi має `keycrmId` 27, хоча в KeyCRM цей пояс має id 49. Зараз рятує запасне зіставлення за назвою, але id варто виправити.

## Перевірка

`pnpm type-check`, `pnpm lint`, `pnpm test` зелені (141 тест, з них 6 нових на `sizeDisplayText`).

Обидва леяути перевірені в браузері на 1440 і на 390: панелі на місці, тексти зі Strapi підтягуються, підказка прокрутки їде і зупиняється від дотику.

## Чого тут немає

Правки в `components/models/model-loader.tsx` і скрипт `pnpm check:webgl` лишились поза цим MR. Це окрема тема про втрату WebGL-контексту, піде своїм PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)